### PR TITLE
fix: 랜딩/프라이버시 페이지 서버 데이터 저장 문구 수정

### DIFF
--- a/app/(static)/privacy/page.tsx
+++ b/app/(static)/privacy/page.tsx
@@ -181,11 +181,11 @@ export default function PrivacyPolicy() {
                   3.2 Server-Side Storage
                 </h3>
                 <p className="text-foreground leading-relaxed">
-                  We do not maintain a server-side database of user data. Our servers
-                  (hosted on Vercel) process requests but do not persistently store
-                  personal information. The only server-side operation involving your data
-                  is the GitHub OAuth token exchange, which is processed in real time and
-                  not stored.
+                  When you sign in with GitHub, your profile and preferences are stored in
+                  a secure cloud database (Supabase) tied to your account. This enables
+                  cross-device sync. If you use the service without signing in, no data is
+                  stored on our servers. Row-level security ensures only you can read or
+                  write your own data.
                 </p>
               </div>
 
@@ -504,9 +504,9 @@ export default function PrivacyPolicy() {
                 and is never sent to or stored on our servers.
               </li>
               <li>
-                <strong className="text-foreground">No Server Database:</strong> We do not
-                maintain a server-side database of user credentials or personal
-                information, minimizing the risk of data breaches on our end.
+                <strong className="text-foreground">Row-Level Security:</strong> Our cloud
+                database enforces row-level security so only you can access your own data.
+                Anonymous usage stores nothing server-side.
               </li>
               <li>
                 <strong className="text-foreground">OAuth Security:</strong> We use

--- a/app/(static)/privacy/page.tsx
+++ b/app/(static)/privacy/page.tsx
@@ -183,9 +183,9 @@ export default function PrivacyPolicy() {
                 <p className="text-foreground leading-relaxed">
                   When you sign in with GitHub, your profile and preferences are stored in
                   a secure cloud database (Supabase) tied to your account. This enables
-                  cross-device sync. If you use the service without signing in, no data is
-                  stored on our servers. Row-level security ensures only you can read or
-                  write your own data.
+                  cross-device sync. If you use the service without signing in, no
+                  personal information or preferences are stored on our servers. Row-level
+                  security ensures only you can read or write your own data.
                 </p>
               </div>
 
@@ -506,7 +506,7 @@ export default function PrivacyPolicy() {
               <li>
                 <strong className="text-foreground">Row-Level Security:</strong> Our cloud
                 database enforces row-level security so only you can access your own data.
-                Anonymous usage stores nothing server-side.
+                Anonymous usage stores no personal information server-side.
               </li>
               <li>
                 <strong className="text-foreground">OAuth Security:</strong> We use

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -126,10 +126,8 @@ export default function LandingPage() {
               <p className="text-muted-foreground text-sm mt-1">Free to Use</p>
             </div>
             <div>
-              <p className="text-3xl font-bold text-primary">0</p>
-              <p className="text-muted-foreground text-sm mt-1">
-                Data Stored Server-Side
-              </p>
+              <p className="text-3xl font-bold text-primary">Opt-In</p>
+              <p className="text-muted-foreground text-sm mt-1">Cloud Sync</p>
             </div>
             <div>
               <p className="text-3xl font-bold text-primary">Open</p>


### PR DESCRIPTION
## Summary
- Supabase 도입 후 사실과 다른 "0 Data Stored Server-Side" 문구 수정
- 랜딩 페이지: "Opt-In Cloud Sync"으로 변경
- 프라이버시 정책: 실제 Supabase 아키텍처 및 RLS 보안 설명으로 업데이트

## Test plan
- [ ] 랜딩 페이지 통계 섹션에서 "Opt-In / Cloud Sync" 표시 확인
- [ ] 프라이버시 페이지 3.2절, 7절 내용이 현재 아키텍처와 일치하는지 확인

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)