### PR TITLE
feat: 이슈 카드에 경쟁 상태 배지 표시

### DIFF
--- a/app/components/IssueItem.tsx
+++ b/app/components/IssueItem.tsx
@@ -44,11 +44,31 @@ const maintainerGradeStyles = {
   C: 'bg-muted text-muted-foreground',
 };
 
+type CompetitionStatus = 'available' | 'inProgress' | 'hot';
+
+const getCompetitionStatus = (
+  comments: number | undefined,
+  assignee: string | null | undefined,
+): CompetitionStatus => {
+  if (assignee) return 'inProgress';
+  if ((comments ?? 0) >= 5) return 'hot';
+  return 'available';
+};
+
+const competitionStatusStyles: Record<CompetitionStatus, string> = {
+  available: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
+  inProgress: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
+  hot: 'bg-red-500/15 text-red-400 border-red-500/20',
+};
+
 const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
   const t = useTranslations();
   const tCommon = useTranslations('common');
   const tMaintainer = useTranslations('maintainer');
+  const tIssue = useTranslations('issue');
   const { locale } = useLocaleSwitch();
+
+  const competitionStatus = getCompetitionStatus(issue.comments, issue.assignee);
 
   if (compact) {
     return (
@@ -107,6 +127,15 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
                   {tMaintainer(`grade${issue.repository.maintainerScore.grade}`)}
                 </Badge>
               )}
+              <Badge
+                variant="outline"
+                className={cn(
+                  'text-xs px-1.5 py-0.5 rounded',
+                  competitionStatusStyles[competitionStatus],
+                )}
+              >
+                {tIssue(`status.${competitionStatus}`)}
+              </Badge>
             </div>
           </div>
 
@@ -195,6 +224,16 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
                 {tMaintainer(`grade${issue.repository.maintainerScore.grade}`)}
               </Badge>
             )}
+
+            <Badge
+              variant="outline"
+              className={cn(
+                'text-xs px-2.5 py-0.5 rounded',
+                competitionStatusStyles[competitionStatus],
+              )}
+            >
+              {tIssue(`status.${competitionStatus}`)}
+            </Badge>
           </div>
 
           <div className="flex flex-wrap gap-1.5 mt-2">

--- a/app/components/IssueItem.tsx
+++ b/app/components/IssueItem.tsx
@@ -51,7 +51,7 @@ const getCompetitionStatus = (
   assignee: string | null | undefined,
 ): CompetitionStatus => {
   if (assignee) return 'inProgress';
-  if ((comments ?? 0) >= 5) return 'hot';
+  if ((comments ?? 0) >= 3) return 'hot';
   return 'available';
 };
 
@@ -60,6 +60,29 @@ const competitionStatusStyles: Record<CompetitionStatus, string> = {
   inProgress: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
   hot: 'bg-red-500/15 text-red-400 border-red-500/20',
 };
+
+interface CompetitionBadgeProps {
+  status: CompetitionStatus;
+  label: string;
+  compact?: boolean;
+}
+
+const CompetitionBadge: React.FC<CompetitionBadgeProps> = ({
+  status,
+  label,
+  compact,
+}) => (
+  <Badge
+    variant="outline"
+    className={cn(
+      'text-xs py-0.5 rounded',
+      compact ? 'px-1.5' : 'px-2.5',
+      competitionStatusStyles[status],
+    )}
+  >
+    {label}
+  </Badge>
+);
 
 const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
   const t = useTranslations();
@@ -127,15 +150,11 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
                   {tMaintainer(`grade${issue.repository.maintainerScore.grade}`)}
                 </Badge>
               )}
-              <Badge
-                variant="outline"
-                className={cn(
-                  'text-xs px-1.5 py-0.5 rounded',
-                  competitionStatusStyles[competitionStatus],
-                )}
-              >
-                {tIssue(`status.${competitionStatus}`)}
-              </Badge>
+              <CompetitionBadge
+                status={competitionStatus}
+                label={tIssue(`status.${competitionStatus}`)}
+                compact
+              />
             </div>
           </div>
 
@@ -225,15 +244,10 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
               </Badge>
             )}
 
-            <Badge
-              variant="outline"
-              className={cn(
-                'text-xs px-2.5 py-0.5 rounded',
-                competitionStatusStyles[competitionStatus],
-              )}
-            >
-              {tIssue(`status.${competitionStatus}`)}
-            </Badge>
+            <CompetitionBadge
+              status={competitionStatus}
+              label={tIssue(`status.${competitionStatus}`)}
+            />
           </div>
 
           <div className="flex flex-wrap gap-1.5 mt-2">

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -38,6 +38,8 @@ export interface Issue {
   state: 'open' | 'closed';
   repository: Repository;
   isNew?: boolean;
+  comments?: number;
+  assignee?: string | null;
 }
 
 // Saved (picked) issue types

--- a/app/utils/github.ts
+++ b/app/utils/github.ts
@@ -177,6 +177,8 @@ interface GithubIssue {
   created_at: string;
   updated_at: string;
   state: 'open' | 'closed';
+  comments: number;
+  assignee: { login: string } | null;
 }
 
 // Shared helper to convert a GitHub API label (object or string) to our Label type
@@ -212,6 +214,8 @@ const processIssueData = (data: unknown[], repository: Repository): Issue[] => {
       updatedAt: issue.updated_at,
       state: issue.state,
       repository,
+      comments: issue.comments,
+      assignee: issue.assignee?.login ?? null,
     };
   });
 };
@@ -296,6 +300,8 @@ export const getRecommendedIssues = async (language?: string): Promise<Issue[]> 
           name: repoName,
           url: `https://github.com/${repoOwner}/${repoName}`,
         },
+        comments: item.comments,
+        assignee: (item.assignee as { login: string } | null)?.login ?? null,
       };
     });
 
@@ -378,4 +384,3 @@ export const searchRepositories = async (query: string): Promise<Repository[]> =
     return [];
   }
 };
-

--- a/messages/en.json
+++ b/messages/en.json
@@ -156,6 +156,13 @@
       "6m": "Past 6 Months"
     }
   },
+  "issue": {
+    "status": {
+      "available": "Available",
+      "inProgress": "In Progress",
+      "hot": "Hot"
+    }
+  },
   "maintainer": {
     "gradeA": "Responsive",
     "gradeB": "Moderate",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -156,6 +156,13 @@
       "6m": "지난 6달"
     }
   },
+  "issue": {
+    "status": {
+      "available": "참여 가능",
+      "inProgress": "진행 중",
+      "hot": "경쟁 중"
+    }
+  },
   "maintainer": {
     "gradeA": "친절함",
     "gradeB": "보통",


### PR DESCRIPTION
## Summary
- 이슈의 선점 가능 여부를 배지로 시각화 (Available / In Progress / Hot)
- GitHub API 기존 응답 데이터(comments, assignee) 활용, 추가 API 호출 없음
- Issue 타입, 데이터 매핑, IssueItem UI, i18n(EN/KO) 업데이트

## Test plan
- [ ] assignee 없고 댓글 ≤ 2인 이슈에 초록색 "참여 가능" 배지 표시
- [ ] assignee가 있는 이슈에 노란색 "진행 중" 배지 표시
- [ ] 댓글 ≥ 5인 이슈에 빨간색 "경쟁 중" 배지 표시
- [ ] compact / full card 양쪽 뷰에서 배지 정상 표시
- [ ] EN/KO 언어 전환 시 배지 텍스트 정상 변경

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)