### PR TITLE
fix: CI 빌드에 Supabase 더미 환경변수 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,5 @@ jobs:
         env:
           GITHUB_CLIENT_ID: ${{ secrets.GITHUB_CLIENT_ID }}
           GITHUB_CLIENT_SECRET: ${{ secrets.GITHUB_CLIENT_SECRET }}
+          NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY: placeholder-key-for-ci-build


### PR DESCRIPTION
## Summary
- CI Build 단계에서 Supabase 환경변수 미설정으로 `/issues`, `/picked` 페이지 prerender 실패
- `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY` placeholder 값 추가

## Test plan
- [ ] CI 파이프라인 Build 단계가 성공하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)