### PR TITLE
feat: OG 태그 + JSON-LD 구조화 데이터 추가

### DIFF
--- a/app/(static)/about/page.tsx
+++ b/app/(static)/about/page.tsx
@@ -5,6 +5,19 @@ export const metadata: Metadata = {
   title: 'About',
   description:
     'Learn about Pickssue - a platform that helps developers discover beginner-friendly GitHub issues and start their open source journey.',
+  openGraph: {
+    title: 'About Pickssue',
+    description:
+      'Learn about Pickssue - a platform that helps developers discover beginner-friendly GitHub issues and start their open source journey.',
+    url: 'https://pickssue.dev/about',
+    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: 'About Pickssue' }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'About Pickssue',
+    description:
+      'Learn about Pickssue - a platform that helps developers discover beginner-friendly GitHub issues and start their open source journey.',
+  },
 };
 
 export default function AboutPage() {

--- a/app/(static)/about/page.tsx
+++ b/app/(static)/about/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
     title: 'About Pickssue',
     description:
       'Learn about Pickssue - a platform that helps developers discover beginner-friendly GitHub issues and start their open source journey.',
-    url: 'https://pickssue.dev/about',
+    url: '/about',
     images: [{ url: '/og-image.png', width: 1200, height: 630, alt: 'About Pickssue' }],
   },
   twitter: {

--- a/app/(static)/faq/page.tsx
+++ b/app/(static)/faq/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
     title: 'Frequently Asked Questions | Pickssue',
     description:
       'Answers to common questions about Pickssue and open source contribution — from getting started to advancing your career.',
-    url: 'https://pickssue.dev/faq',
+    url: '/faq',
     images: [
       {
         url: '/og-image.png',
@@ -203,10 +203,42 @@ const faqJsonLd = {
     },
     {
       '@type': 'Question',
+      name: 'How do I choose which project to contribute to?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: "Start with software you already use and care about. If you use a tool every day, you understand its purpose, which makes it easier to judge whether a change is correct and valuable. Also consider the project's maintainer responsiveness — look at how quickly recent pull requests were reviewed.",
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'What should I do if my pull request is ignored?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Wait at least one to two weeks before following up, since maintainers are often volunteers. If there is still no response after a polite follow-up comment, it is reasonable to move on to another project. Not every PR gets merged — it is not a reflection of your skill.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: "Can I contribute to open source if my English isn't strong?",
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Yes. Most open source communication happens in writing, which gives you time to look up words, use translation tools, and compose your thoughts carefully. Clear intent matters far more than perfect grammar.',
+      },
+    },
+    {
+      '@type': 'Question',
       name: 'Does open source contribution help with getting a job?',
       acceptedAnswer: {
         '@type': 'Answer',
         text: 'Yes, significantly. Open source contributions create a public, verifiable portfolio of real-world work. Recruiters and engineering managers look at GitHub profiles when evaluating candidates. A history of merged pull requests demonstrates that you can read unfamiliar codebases, communicate with a team, follow conventions, and ship working code.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Are there ways to contribute to open source without writing code?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Many. Writing and improving documentation is one of the highest-impact contributions you can make. You can also triage issues, translate content, design UI/UX improvements, answer questions in community forums, or star and share projects you find valuable.',
       },
     },
   ],

--- a/app/(static)/faq/page.tsx
+++ b/app/(static)/faq/page.tsx
@@ -5,6 +5,26 @@ export const metadata: Metadata = {
   title: 'Frequently Asked Questions',
   description:
     'Answers to common questions about Pickssue and open source contribution — from getting started to advancing your career.',
+  openGraph: {
+    title: 'Frequently Asked Questions | Pickssue',
+    description:
+      'Answers to common questions about Pickssue and open source contribution — from getting started to advancing your career.',
+    url: 'https://pickssue.dev/faq',
+    images: [
+      {
+        url: '/og-image.png',
+        width: 1200,
+        height: 630,
+        alt: 'Pickssue FAQ',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Frequently Asked Questions | Pickssue',
+    description:
+      'Answers to common questions about Pickssue and open source contribution — from getting started to advancing your career.',
+  },
 };
 
 type FAQItem = {
@@ -121,6 +141,77 @@ const contributionQuestions: FAQItem[] = [
   },
 ];
 
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'What is Pickssue?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Pickssue is a free tool that helps developers discover beginner-friendly GitHub issues across multiple repositories in one place. You add the repositories you care about, and the platform surfaces open issues labeled good first issue, help wanted, and similar tags.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Is Pickssue free to use?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Yes, completely free. There are no paid plans, no premium tiers, and no hidden costs. The platform is itself an open source project, so the code is publicly available for anyone to inspect, fork, or self-host.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Do I need to log in with GitHub to use the app?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'No. You can browse issues without signing in. Anonymous usage is fully supported, though you will be subject to GitHub API rate limits. Signing in with GitHub unlocks additional features including cross-device sync, browser notifications, and a higher API rate limit.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'What data does Pickssue collect?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: "When you sign in with GitHub, Pickssue stores your repository list and preferences in a secure cloud database tied to your account. In anonymous mode, settings are saved only in your browser's localStorage. We do not share your data with third parties.",
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'How does cross-device settings sync work?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'When you are signed in with GitHub, your repository list and preferences are automatically saved to a secure cloud database. When you open the app on another device and sign in with the same account, your settings are restored automatically.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'How do browser notifications work?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'If you enable browser notifications in the Settings panel, the app will periodically check your tracked repositories for new beginner-friendly issues and send a browser notification when it finds any. Notifications require browser permission and only work while the app is open.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Can beginners with no professional experience contribute to open source?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Absolutely. Many of the most welcoming open source projects actively seek contributors who are just learning to code. A first contribution does not need to be a complex new feature — fixing a typo in documentation, improving an error message, or adding a test case are all genuinely valuable.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Does open source contribution help with getting a job?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Yes, significantly. Open source contributions create a public, verifiable portfolio of real-world work. Recruiters and engineering managers look at GitHub profiles when evaluating candidates. A history of merged pull requests demonstrates that you can read unfamiliar codebases, communicate with a team, follow conventions, and ship working code.',
+      },
+    },
+  ],
+};
+
 function FAQSection({ title, items }: { title: string; items: FAQItem[] }) {
   return (
     <section className="mb-16">
@@ -145,6 +236,10 @@ function FAQSection({ title, items }: { title: string; items: FAQItem[] }) {
 export default function FAQPage() {
   return (
     <article className="text-foreground">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+      />
       {/* Hero Section */}
       <section className="text-center mb-16">
         <h1 className="text-4xl md:text-5xl font-bold text-foreground mb-6 font-[family-name:var(--font-mono)]">

--- a/app/(static)/guide/page.tsx
+++ b/app/(static)/guide/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
     title: 'How to Make Your First Open Source Contribution',
     description:
       'A comprehensive guide for beginners on making your first open source contribution — from finding the right issue to getting your pull request merged.',
-    url: 'https://pickssue.dev/guide',
+    url: '/guide',
     images: [
       {
         url: '/og-image.png',
@@ -27,6 +27,7 @@ export const metadata: Metadata = {
   },
 };
 
+// TODO: Extract step text to shared constants shared with the UI to avoid duplication in a future refactor.
 const howToJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'HowTo',

--- a/app/(static)/guide/page.tsx
+++ b/app/(static)/guide/page.tsx
@@ -5,11 +5,87 @@ export const metadata: Metadata = {
   title: 'How to Make Your First Open Source Contribution',
   description:
     'A comprehensive guide for beginners on making your first open source contribution — from finding the right issue to getting your pull request merged.',
+  openGraph: {
+    title: 'How to Make Your First Open Source Contribution',
+    description:
+      'A comprehensive guide for beginners on making your first open source contribution — from finding the right issue to getting your pull request merged.',
+    url: 'https://pickssue.dev/guide',
+    images: [
+      {
+        url: '/og-image.png',
+        width: 1200,
+        height: 630,
+        alt: 'Beginner guide to open source contributions',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'How to Make Your First Open Source Contribution',
+    description:
+      'A comprehensive guide for beginners on making your first open source contribution — from finding the right issue to getting your pull request merged.',
+  },
+};
+
+const howToJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: 'How to Make Your First Open Source Contribution',
+  description:
+    'A step-by-step guide for beginners on making their first open source contribution — from finding the right issue to getting a pull request merged.',
+  step: [
+    {
+      '@type': 'HowToStep',
+      position: 1,
+      name: 'Comment on the Issue',
+      text: 'Before writing any code, leave a comment on the issue saying you would like to work on it. This prevents duplicate effort and gives the maintainer a chance to clarify requirements.',
+    },
+    {
+      '@type': 'HowToStep',
+      position: 2,
+      name: 'Fork the Repository',
+      text: 'Click the Fork button on the GitHub repository page. This creates a copy of the entire repository under your GitHub account with full write access.',
+    },
+    {
+      '@type': 'HowToStep',
+      position: 3,
+      name: 'Clone Your Fork Locally',
+      text: 'Run git clone to download the repository to your computer. Then run the project locally following the instructions in the README to confirm everything works.',
+    },
+    {
+      '@type': 'HowToStep',
+      position: 4,
+      name: 'Create a New Branch',
+      text: 'Never work directly on the main branch. Create a descriptive branch for your change using git checkout -b.',
+    },
+    {
+      '@type': 'HowToStep',
+      position: 5,
+      name: 'Write Your Code',
+      text: 'Make the smallest change that solves the problem. Read the existing code carefully and match the style. Run the existing test suite to confirm nothing is broken.',
+    },
+    {
+      '@type': 'HowToStep',
+      position: 6,
+      name: 'Commit with a Clear Message',
+      text: 'Write a commit message that explains what you changed and why. Many projects follow the Conventional Commits format.',
+    },
+    {
+      '@type': 'HowToStep',
+      position: 7,
+      name: 'Push and Open a Pull Request',
+      text: 'Push your branch to your fork, then go to the original repository on GitHub and open a pull request. Fill in the PR template and submit.',
+    },
+  ],
 };
 
 export default function GuidePage() {
   return (
     <article className="text-foreground">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(howToJsonLd) }}
+      />
       {/* Hero Section */}
       <section className="text-center mb-16">
         <h1 className="text-4xl md:text-5xl font-bold text-foreground mb-6 font-[family-name:var(--font-mono)]">

--- a/app/(static)/privacy/page.tsx
+++ b/app/(static)/privacy/page.tsx
@@ -6,7 +6,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'Privacy Policy | Pickssue',
     description: 'Privacy Policy for Pickssue - Learn how we handle your data.',
-    url: 'https://pickssue.dev/privacy',
+    url: '/privacy',
     images: [
       {
         url: '/og-image.png',

--- a/app/(static)/privacy/page.tsx
+++ b/app/(static)/privacy/page.tsx
@@ -3,6 +3,24 @@ import type { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'Privacy Policy',
   description: 'Privacy Policy for Pickssue - Learn how we handle your data.',
+  openGraph: {
+    title: 'Privacy Policy | Pickssue',
+    description: 'Privacy Policy for Pickssue - Learn how we handle your data.',
+    url: 'https://pickssue.dev/privacy',
+    images: [
+      {
+        url: '/og-image.png',
+        width: 1200,
+        height: 630,
+        alt: 'Pickssue Privacy Policy',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Privacy Policy | Pickssue',
+    description: 'Privacy Policy for Pickssue - Learn how we handle your data.',
+  },
 };
 
 export default function PrivacyPolicy() {

--- a/app/(static)/terms/page.tsx
+++ b/app/(static)/terms/page.tsx
@@ -4,6 +4,24 @@ import Link from 'next/link';
 export const metadata: Metadata = {
   title: 'Terms of Service',
   description: 'Terms of Service for Pickssue.',
+  openGraph: {
+    title: 'Terms of Service | Pickssue',
+    description: 'Terms of Service for Pickssue.',
+    url: 'https://pickssue.dev/terms',
+    images: [
+      {
+        url: '/og-image.png',
+        width: 1200,
+        height: 630,
+        alt: 'Pickssue Terms of Service',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Terms of Service | Pickssue',
+    description: 'Terms of Service for Pickssue.',
+  },
 };
 
 export default function TermsOfService() {

--- a/app/(static)/terms/page.tsx
+++ b/app/(static)/terms/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'Terms of Service | Pickssue',
     description: 'Terms of Service for Pickssue.',
-    url: 'https://pickssue.dev/terms',
+    url: '/terms',
     images: [
       {
         url: '/og-image.png',

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -65,7 +65,7 @@ export const metadata: Metadata = {
     title: 'Pickssue',
     description:
       'A personalized open-source contribution curator that analyzes your GitHub activity to recommend the best issues for you.',
-    url: 'https://pickssue.dev',
+    url: '/',
     siteName: 'Pickssue',
     type: 'website',
     images: [

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -55,9 +55,51 @@ const jetbrainsMono = JetBrains_Mono({
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://pickssue.dev'),
-  title: 'Pickssue',
+  title: {
+    default: 'Pickssue',
+    template: '%s | Pickssue',
+  },
   description:
     'A personalized open-source contribution curator that analyzes your GitHub activity to recommend the best issues for you.',
+  openGraph: {
+    title: 'Pickssue',
+    description:
+      'A personalized open-source contribution curator that analyzes your GitHub activity to recommend the best issues for you.',
+    url: 'https://pickssue.dev',
+    siteName: 'Pickssue',
+    type: 'website',
+    images: [
+      {
+        url: '/og-image.png',
+        width: 1200,
+        height: 630,
+        alt: 'Pickssue - Find beginner-friendly GitHub issues',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Pickssue',
+    description:
+      'A personalized open-source contribution curator that analyzes your GitHub activity to recommend the best issues for you.',
+    images: ['/og-image.png'],
+  },
+};
+
+const webApplicationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebApplication',
+  name: 'Pickssue',
+  url: 'https://pickssue.dev',
+  description:
+    'A personalized open-source contribution curator that analyzes your GitHub activity to recommend the best issues for you.',
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'Any',
+  offers: {
+    '@type': 'Offer',
+    price: '0',
+    priceCurrency: 'USD',
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -65,6 +107,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" suppressHydrationWarning>
       <head>
         <meta name="google-adsense-account" content="ca-pub-9157231737129938" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(webApplicationJsonLd) }}
+        />
         {env.NEXT_PUBLIC_ADSENSE_CLIENT_ID && (
           <Script
             async


### PR DESCRIPTION
## Summary
- 모든 페이지에 Open Graph / Twitter Card 메타데이터 추가
- 루트 레이아웃에 `WebApplication` JSON-LD 스키마 추가
- FAQ 페이지에 `FAQPage` JSON-LD 스키마 추가 (8개 Q&A)
- Guide 페이지에 `HowTo` JSON-LD 스키마 추가 (7단계)
- 각 정적 페이지별 개별 OG title/description 설정

## Test plan
- [ ] Facebook Sharing Debugger에서 주요 페이지 프리뷰 정상 확인
- [ ] Twitter Card Validator에서 summary_large_image 카드 확인
- [ ] Google Rich Results Test에서 FAQ/HowTo 스키마 유효성 통과
- [ ] 각 정적 페이지의 `<head>`에 og/twitter 메타태그 존재 확인

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)