### PR TITLE
style: 이슈 카드 배지 시각적 구분 개선

### DIFF
--- a/app/components/IssueItem.tsx
+++ b/app/components/IssueItem.tsx
@@ -63,9 +63,9 @@ const competitionStatusStyles: Record<CompetitionStatus, string> = {
 };
 
 const competitionStatusIcons: Record<CompetitionStatus, React.ReactNode> = {
-  available: <LuCircleDot className="shrink-0" size={10} />,
-  inProgress: <LuUsers className="shrink-0" size={10} />,
-  hot: <LuFlame className="shrink-0" size={10} />,
+  available: <LuCircleDot className="shrink-0 size-2.5" />,
+  inProgress: <LuUsers className="shrink-0 size-2.5" />,
+  hot: <LuFlame className="shrink-0 size-2.5" />,
 };
 
 interface CompetitionBadgeProps {
@@ -147,7 +147,10 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
                 </span>
               )}
               {issue.labels.length > 0 && (
-                <span className="text-muted-foreground/30 text-xs mx-0.5 select-none">
+                <span
+                  className="text-muted-foreground/30 text-xs mx-0.5 select-none"
+                  aria-hidden="true"
+                >
                   |
                 </span>
               )}
@@ -160,7 +163,7 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
                   )}
                   title={`${tMaintainer(`grade${issue.repository.maintainerScore.grade}`)} · ${tMaintainer('responseTime', { hours: Math.round(issue.repository.maintainerScore.avgResponseTimeHours) })} · ${tMaintainer('mergeRate', { rate: Math.round(issue.repository.maintainerScore.mergeRate * 100) })}`}
                 >
-                  <LuShield className="shrink-0" size={10} />
+                  <LuShield className="shrink-0 size-2.5" />
                   {tMaintainer(`grade${issue.repository.maintainerScore.grade}`)}
                 </Badge>
               )}
@@ -253,7 +256,7 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
                 )}
                 title={`${tMaintainer('responseTime', { hours: Math.round(issue.repository.maintainerScore.avgResponseTimeHours) })} · ${tMaintainer('mergeRate', { rate: Math.round(issue.repository.maintainerScore.mergeRate * 100) })}`}
               >
-                <LuShield className="shrink-0" size={11} />
+                <LuShield className="shrink-0 size-[11px]" />
                 {issue.repository.maintainerScore.grade} ·{' '}
                 {tMaintainer(`grade${issue.repository.maintainerScore.grade}`)}
               </Badge>

--- a/app/components/IssueItem.tsx
+++ b/app/components/IssueItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Issue } from '../types';
 import { FaGithub, FaClock, FaStar, FaCodeBranch } from 'react-icons/fa';
+import { LuShield, LuCircleDot, LuUsers, LuFlame } from 'react-icons/lu';
 import { useTranslations } from 'next-intl';
 import { useLocaleSwitch } from '@/app/providers/IntlProvider';
 import { Card } from '@/components/ui/card';
@@ -61,6 +62,12 @@ const competitionStatusStyles: Record<CompetitionStatus, string> = {
   hot: 'bg-red-500/15 text-red-400 border-red-500/20',
 };
 
+const competitionStatusIcons: Record<CompetitionStatus, React.ReactNode> = {
+  available: <LuCircleDot className="shrink-0" size={10} />,
+  inProgress: <LuUsers className="shrink-0" size={10} />,
+  hot: <LuFlame className="shrink-0" size={10} />,
+};
+
 interface CompetitionBadgeProps {
   status: CompetitionStatus;
   label: string;
@@ -75,11 +82,12 @@ const CompetitionBadge: React.FC<CompetitionBadgeProps> = ({
   <Badge
     variant="outline"
     className={cn(
-      'text-xs py-0.5 rounded',
-      compact ? 'px-1.5' : 'px-2.5',
+      'inline-flex items-center gap-1 text-xs py-0.5 rounded font-medium',
+      compact ? 'px-1.5' : 'px-2',
       competitionStatusStyles[status],
     )}
   >
+    {competitionStatusIcons[status]}
     {label}
   </Badge>
 );
@@ -119,12 +127,12 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
               </a>
             </h3>
 
-            <div className="flex flex-wrap gap-1 mt-1">
+            <div className="flex flex-wrap items-center gap-1 mt-1">
               {issue.labels.slice(0, 3).map(label => (
                 <Badge
                   key={label.id}
                   variant="outline"
-                  className="text-xs px-1.5 py-0.5 rounded border-none"
+                  className="text-xs px-1.5 py-0.5 rounded-full border-none"
                   style={{
                     backgroundColor: `#${label.color}15`,
                     color: `#${label.color}`,
@@ -138,15 +146,21 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
                   +{issue.labels.length - 3}
                 </span>
               )}
+              {issue.labels.length > 0 && (
+                <span className="text-muted-foreground/30 text-xs mx-0.5 select-none">
+                  |
+                </span>
+              )}
               {issue.repository.maintainerScore && (
                 <Badge
                   variant="outline"
                   className={cn(
-                    'text-xs px-1.5 py-0.5 rounded border-none',
+                    'inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded border-none',
                     maintainerGradeStyles[issue.repository.maintainerScore.grade],
                   )}
                   title={`${tMaintainer(`grade${issue.repository.maintainerScore.grade}`)} · ${tMaintainer('responseTime', { hours: Math.round(issue.repository.maintainerScore.avgResponseTimeHours) })} · ${tMaintainer('mergeRate', { rate: Math.round(issue.repository.maintainerScore.mergeRate * 100) })}`}
                 >
+                  <LuShield className="shrink-0" size={10} />
                   {tMaintainer(`grade${issue.repository.maintainerScore.grade}`)}
                 </Badge>
               )}
@@ -234,11 +248,12 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
               <Badge
                 variant="outline"
                 className={cn(
-                  'text-xs px-2 py-0.5 rounded border-none',
+                  'inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded border-none',
                   maintainerGradeStyles[issue.repository.maintainerScore.grade],
                 )}
                 title={`${tMaintainer('responseTime', { hours: Math.round(issue.repository.maintainerScore.avgResponseTimeHours) })} · ${tMaintainer('mergeRate', { rate: Math.round(issue.repository.maintainerScore.mergeRate * 100) })}`}
               >
+                <LuShield className="shrink-0" size={11} />
                 {issue.repository.maintainerScore.grade} ·{' '}
                 {tMaintainer(`grade${issue.repository.maintainerScore.grade}`)}
               </Badge>


### PR DESCRIPTION
## Summary
- 라벨(pill, rounded-full)과 메타 배지(rectangular, rounded)의 형태 차별화
- 메인테이너 등급에 Shield 아이콘 접두사 추가
- 경쟁 상태에 상태별 아이콘 추가 (CircleDot/Users/Flame)
- compact 뷰에서 라벨과 메타 배지 사이에 구분자 추가

## Test plan
- [ ] compact 뷰: 라벨과 메타 배지가 시각적으로 구분되는지 확인
- [ ] full card 뷰: 메인테이너/경쟁 상태 배지에 아이콘 표시 확인
- [ ] 라벨 0개일 때 구분자가 표시되지 않는지 확인
- [ ] 라벨 5개 이상일 때 레이아웃이 깨지지 않는지 확인

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)