### PR TITLE
feat: 이슈 카드 공유 버튼 추가

### DIFF
--- a/app/components/IssueItem.tsx
+++ b/app/components/IssueItem.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Issue } from '../types';
 import { FaGithub, FaClock, FaStar, FaCodeBranch } from 'react-icons/fa';
-import { LuShield, LuCircleDot, LuUsers, LuFlame } from 'react-icons/lu';
+import { LuShield, LuCircleDot, LuUsers, LuFlame, LuShare2 } from 'react-icons/lu';
 import { useTranslations } from 'next-intl';
 import { useLocaleSwitch } from '@/app/providers/IntlProvider';
 import { Card } from '@/components/ui/card';
@@ -98,8 +98,37 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
   const tMaintainer = useTranslations('maintainer');
   const tIssue = useTranslations('issue');
   const { locale } = useLocaleSwitch();
+  const [copied, setCopied] = useState(false);
 
   const competitionStatus = getCompetitionStatus(issue.comments, issue.assignee);
+
+  const shareUrl = `${issue.url}?utm_source=pickssue&utm_medium=share`;
+  const shareTitle = `${issue.title} - ${issue.repository.owner}/${issue.repository.name} #${issue.number}`;
+  const shareText = `${shareTitle}\n${tCommon('shareText')}`;
+
+  const handleShare = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (typeof navigator !== 'undefined' && navigator.share) {
+      try {
+        await navigator.share({
+          title: shareTitle,
+          text: tCommon('shareText'),
+          url: shareUrl,
+        });
+      } catch {
+        // user cancelled or error — no action needed
+      }
+    } else {
+      try {
+        await navigator.clipboard.writeText(`${shareText}\n${shareUrl}`);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch {
+        // clipboard not available
+      }
+    }
+  };
 
   if (compact) {
     return (
@@ -206,6 +235,21 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
                   {t('common.new')}
                 </Badge>
               )}
+              <div className="relative">
+                <button
+                  onClick={handleShare}
+                  title={tCommon('share')}
+                  className="inline-flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors p-0.5 rounded"
+                  aria-label={tCommon('share')}
+                >
+                  <LuShare2 className="size-3" />
+                </button>
+                {copied && (
+                  <span className="absolute right-0 bottom-full mb-1 whitespace-nowrap rounded bg-foreground px-1.5 py-0.5 text-[10px] text-background">
+                    {tCommon('copied')}
+                  </span>
+                )}
+              </div>
             </div>
           </div>
         </div>
@@ -325,15 +369,32 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
               </span>
             </div>
 
-            <a
-              href={issue.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center text-primary hover:text-primary/80 transition-colors ml-auto text-xs"
-            >
-              <FaGithub className="mr-1" />
-              <span>{t('common.viewIssue')}</span>
-            </a>
+            <div className="flex items-center gap-2 ml-auto">
+              <a
+                href={issue.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center text-primary hover:text-primary/80 transition-colors text-xs"
+              >
+                <FaGithub className="mr-1" />
+                <span>{t('common.viewIssue')}</span>
+              </a>
+              <div className="relative">
+                <button
+                  onClick={handleShare}
+                  title={tCommon('share')}
+                  className="inline-flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors p-1 rounded"
+                  aria-label={tCommon('share')}
+                >
+                  <LuShare2 className="size-3.5" />
+                </button>
+                {copied && (
+                  <span className="absolute right-0 bottom-full mb-1 whitespace-nowrap rounded bg-foreground px-1.5 py-0.5 text-[10px] text-background">
+                    {tCommon('copied')}
+                  </span>
+                )}
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/app/components/IssueItem.tsx
+++ b/app/components/IssueItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Issue } from '../types';
 import { FaGithub, FaClock, FaStar, FaCodeBranch } from 'react-icons/fa';
 import { LuShield, LuCircleDot, LuUsers, LuFlame, LuShare2 } from 'react-icons/lu';
@@ -92,6 +92,41 @@ const CompetitionBadge: React.FC<CompetitionBadgeProps> = ({
   </Badge>
 );
 
+interface ShareButtonProps {
+  onClick: (e: React.MouseEvent) => void;
+  label: string;
+  copied: boolean;
+  copiedLabel: string;
+  compact?: boolean;
+}
+
+const ShareButton: React.FC<ShareButtonProps> = ({
+  onClick,
+  label,
+  copied,
+  copiedLabel,
+  compact,
+}) => (
+  <div className="relative">
+    <button
+      onClick={onClick}
+      title={label}
+      className={cn(
+        'inline-flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors rounded',
+        compact ? 'p-0.5' : 'p-1',
+      )}
+      aria-label={label}
+    >
+      <LuShare2 className={compact ? 'size-3' : 'size-3.5'} />
+    </button>
+    {copied && (
+      <span className="absolute right-0 bottom-full mb-1 whitespace-nowrap rounded bg-foreground px-1.5 py-0.5 text-[10px] text-background">
+        {copiedLabel}
+      </span>
+    )}
+  </div>
+);
+
 const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
   const t = useTranslations();
   const tCommon = useTranslations('common');
@@ -99,6 +134,13 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
   const tIssue = useTranslations('issue');
   const { locale } = useLocaleSwitch();
   const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
 
   const competitionStatus = getCompetitionStatus(issue.comments, issue.assignee);
 
@@ -113,7 +155,7 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
       try {
         await navigator.share({
           title: shareTitle,
-          text: tCommon('shareText'),
+          text: shareText,
           url: shareUrl,
         });
       } catch {
@@ -123,7 +165,8 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
       try {
         await navigator.clipboard.writeText(`${shareText}\n${shareUrl}`);
         setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        if (timerRef.current) clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(() => setCopied(false), 2000);
       } catch {
         // clipboard not available
       }
@@ -235,21 +278,13 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
                   {t('common.new')}
                 </Badge>
               )}
-              <div className="relative">
-                <button
-                  onClick={handleShare}
-                  title={tCommon('share')}
-                  className="inline-flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors p-0.5 rounded"
-                  aria-label={tCommon('share')}
-                >
-                  <LuShare2 className="size-3" />
-                </button>
-                {copied && (
-                  <span className="absolute right-0 bottom-full mb-1 whitespace-nowrap rounded bg-foreground px-1.5 py-0.5 text-[10px] text-background">
-                    {tCommon('copied')}
-                  </span>
-                )}
-              </div>
+              <ShareButton
+                onClick={handleShare}
+                label={tCommon('share')}
+                copied={copied}
+                copiedLabel={tCommon('copied')}
+                compact
+              />
             </div>
           </div>
         </div>
@@ -379,21 +414,12 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
                 <FaGithub className="mr-1" />
                 <span>{t('common.viewIssue')}</span>
               </a>
-              <div className="relative">
-                <button
-                  onClick={handleShare}
-                  title={tCommon('share')}
-                  className="inline-flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors p-1 rounded"
-                  aria-label={tCommon('share')}
-                >
-                  <LuShare2 className="size-3.5" />
-                </button>
-                {copied && (
-                  <span className="absolute right-0 bottom-full mb-1 whitespace-nowrap rounded bg-foreground px-1.5 py-0.5 text-[10px] text-background">
-                    {tCommon('copied')}
-                  </span>
-                )}
-              </div>
+              <ShareButton
+                onClick={handleShare}
+                label={tCommon('share')}
+                copied={copied}
+                copiedLabel={tCommon('copied')}
+              />
             </div>
           </div>
         </div>

--- a/messages/en.json
+++ b/messages/en.json
@@ -27,7 +27,10 @@
     "minutesAgo": "{minutes}m ago",
     "hoursAgo": "{hours}h ago",
     "daysAgo": "{days}d ago",
-    "loading": "Loading..."
+    "loading": "Loading...",
+    "share": "Share",
+    "copied": "Copied!",
+    "shareText": "Found on Pickssue"
   },
   "navigation": {
     "home": "Home",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -27,7 +27,10 @@
     "minutesAgo": "{minutes}분 전",
     "hoursAgo": "{hours}시간 전",
     "daysAgo": "{days}일 전",
-    "loading": "불러오는 중..."
+    "loading": "불러오는 중...",
+    "share": "공유",
+    "copied": "복사됨!",
+    "shareText": "Pickssue에서 발견"
   },
   "navigation": {
     "home": "홈",


### PR DESCRIPTION
## Summary
- 이슈 카드에 공유 버튼 추가 (compact/full 양쪽 뷰)
- 모바일: Web Share API로 네이티브 공유 시트 오픈
- 데스크톱: 클립보드 복사 + "복사됨!" 피드백 (2초 후 사라짐)
- 공유 URL에 UTM 파라미터 포함 (`?utm_source=pickssue&utm_medium=share`)
- 공유 텍스트에 "Found on Pickssue" 워터마크 포함
- EN/KO i18n 지원

## Test plan
- [ ] 모바일: 공유 버튼 탭 시 네이티브 공유 시트 오픈
- [ ] 데스크톱: 공유 버튼 클릭 시 클립보드에 URL 복사 + "복사됨!" 표시
- [ ] compact 뷰에서 공유 버튼 정상 표시
- [ ] full card 뷰에서 "View on GitHub" 옆에 공유 버튼 표시
- [ ] 복사된 URL에 UTM 파라미터 포함 확인
- [ ] EN/KO 전환 시 "Share"/"공유", "Copied!"/"복사됨!" 텍스트 변경

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)