### PR TITLE
feat: picked_issues 데이터 정규화 (JSON blob → 별도 테이블)

### DIFF
--- a/app/components/RecommendedIssues.tsx
+++ b/app/components/RecommendedIssues.tsx
@@ -41,7 +41,7 @@ function formatRelativeTime(isoString: string | null, t: any): string {
 export default function RecommendedIssues() {
   const t = useTranslations();
   const {
-    settings,
+    pickedIssues,
     pickIssue,
     unpickIssue,
     authState,
@@ -70,7 +70,7 @@ export default function RecommendedIssues() {
   const [isPersonalized, setIsPersonalized] = useState(false);
 
   // Track which issues are already picked
-  const pickedIssueIds = new Set(settings.pickedIssues.map(s => s.id));
+  const pickedIssueIds = new Set(pickedIssues.map(s => s.id));
 
   const fetchFromApi = useCallback(
     async (currentPage: number, append: boolean) => {

--- a/app/contexts/AppContext.tsx
+++ b/app/contexts/AppContext.tsx
@@ -21,9 +21,6 @@ interface AppContextType {
   settings: ReturnType<typeof useSettings>['settings'];
   settingsLoading: boolean;
   settingsError: string | null;
-  pickIssue: (issue: Issue) => Promise<boolean>;
-  unpickIssue: (issueId: string) => Promise<void>;
-  updateIssueTags: (issueId: string, tags: string[]) => Promise<void>;
   updateNotificationFrequency: ReturnType<
     typeof useSettings
   >['updateNotificationFrequency'];
@@ -33,6 +30,9 @@ interface AppContextType {
   pickedIssues: ReturnType<typeof usePickedIssues>['pickedIssues'];
   pickedIssuesLoading: boolean;
   pickedIssuesError: string | null;
+  pickIssue: (issue: Issue) => Promise<boolean>;
+  unpickIssue: (issueId: string) => Promise<void>;
+  updateIssueTags: (issueId: string, tags: string[]) => Promise<void>;
   refreshPickedIssues: () => Promise<StateChange[]>;
 
   // Recommended Issues
@@ -58,27 +58,26 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   // Auth state via Supabase
   const { authState, login, logout } = useSupabaseAuth();
 
-  // Settings state
+  // Settings state (no longer manages picked issues)
   const {
     settings,
     loading: settingsLoading,
     error: settingsError,
-    pickIssue,
-    unpickIssue,
-    updateIssueTags,
     updateNotificationFrequency,
     toggleHideClosedIssues,
     updateLastCheckedAt,
-    saveUserSettings,
   } = useSettings(authState.isLoggedIn, authState.userId);
 
-  // Picked issues state — uses saveUserSettings for persistence (localStorage + Supabase)
+  // Picked issues state — uses its own Supabase table
   const {
     pickedIssues,
     loading: pickedIssuesLoading,
     error: pickedIssuesError,
+    pickIssue,
+    unpickIssue,
+    updateIssueTags,
     refreshPickedIssues: _refreshPickedIssues,
-  } = usePickedIssues(settings, saveUserSettings, authState.accessToken);
+  } = usePickedIssues(authState.isLoggedIn, authState.userId, authState.accessToken);
 
   // Wrap refreshPickedIssues to show aggregated notifications
   const refreshPickedIssues = useCallback(async () => {
@@ -147,7 +146,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   // Setup periodic checks for picked issue state changes
   useEffect(() => {
     if (settings.notificationFrequency === 'never') return;
-    if (settings.pickedIssues.length === 0) return;
+    if (pickedIssues.length === 0) return;
 
     let interval: NodeJS.Timeout;
 
@@ -168,7 +167,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     return () => {
       if (interval) clearInterval(interval);
     };
-  }, [settings.notificationFrequency, settings.pickedIssues.length, refreshPickedIssues]);
+  }, [settings.notificationFrequency, pickedIssues.length, refreshPickedIssues]);
 
   const value: AppContextType = {
     authState,
@@ -177,14 +176,14 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     settings,
     settingsLoading,
     settingsError,
-    pickIssue,
-    unpickIssue,
-    updateIssueTags,
     updateNotificationFrequency,
     toggleHideClosedIssues,
     pickedIssues,
     pickedIssuesLoading,
     pickedIssuesError,
+    pickIssue,
+    unpickIssue,
+    updateIssueTags,
     refreshPickedIssues,
     recommendedIssues,
     recommendedLoading,

--- a/app/hooks/usePickedIssues.ts
+++ b/app/hooks/usePickedIssues.ts
@@ -1,6 +1,16 @@
-import { useCallback, useState } from 'react';
-import { PickedIssue, UserSettings } from '../types';
+import { useCallback, useState, useEffect } from 'react';
+import { PickedIssue, Issue } from '../types';
+import { Database } from '../types/supabase';
+
+type PickedIssueRow = Database['public']['Tables']['picked_issues']['Row'];
 import { Octokit } from '@octokit/rest';
+import {
+  loadPickedIssues as loadFromSupabase,
+  pickIssue as pickToSupabase,
+  unpickIssue as unpickFromSupabase,
+  updatePickedIssue,
+  bulkUpdatePickedIssues,
+} from '../lib/supabase/pickedIssues';
 
 interface StateChange {
   issue: PickedIssue;
@@ -24,17 +34,112 @@ async function batchProcess<T, R>(
   return results;
 }
 
-const usePickedIssues = (
-  settings: UserSettings,
-  persistSettings: (newSettings: UserSettings) => Promise<boolean>,
-  accessToken?: string,
-) => {
+const usePickedIssues = (isLoggedIn: boolean, userId?: string, accessToken?: string) => {
+  const [pickedIssues, setPickedIssues] = useState<PickedIssue[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Load picked issues from Supabase on mount / auth change
+  useEffect(() => {
+    if (!isLoggedIn || !userId) {
+      setPickedIssues([]);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    loadFromSupabase(userId)
+      .then(issues => {
+        if (!cancelled) setPickedIssues(issues);
+      })
+      .catch(err => {
+        console.error('Error loading picked issues:', err);
+        if (!cancelled) setError('Failed to load picked issues');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoggedIn, userId]);
+
+  // Pick an issue
+  const pickIssue = useCallback(
+    async (issue: Issue): Promise<boolean> => {
+      if (!userId) return false;
+
+      const alreadySaved = pickedIssues.some(s => s.id === issue.id);
+      if (alreadySaved) return false;
+
+      try {
+        const now = new Date().toISOString();
+        const saved: PickedIssue = {
+          id: issue.id,
+          number: issue.number,
+          title: issue.title,
+          url: issue.url,
+          state: issue.state,
+          repository: {
+            owner: issue.repository.owner,
+            name: issue.repository.name,
+          },
+          labels: issue.labels,
+          savedAt: now,
+          userTags: [],
+          lastKnownState: issue.state,
+          lastCheckedAt: now,
+          assignee: undefined,
+        };
+
+        const ok = await pickToSupabase(userId, saved);
+        if (ok) {
+          setPickedIssues(prev => [saved, ...prev]);
+        }
+        return ok;
+      } catch (err) {
+        console.error('Error picking issue:', err);
+        setError('Failed to pick issue');
+        return false;
+      }
+    },
+    [userId, pickedIssues],
+  );
+
+  // Unpick an issue
+  const unpickIssue = useCallback(
+    async (issueId: string): Promise<void> => {
+      if (!userId) return;
+
+      const ok = await unpickFromSupabase(userId, issueId);
+      if (ok) {
+        setPickedIssues(prev => prev.filter(s => s.id !== issueId));
+      }
+    },
+    [userId],
+  );
+
+  // Update user tags on a picked issue
+  const updateIssueTags = useCallback(
+    async (issueId: string, tags: string[]): Promise<void> => {
+      if (!userId) return;
+
+      const ok = await updatePickedIssue(userId, issueId, {
+        user_tags: tags as unknown as PickedIssueRow['user_tags'],
+      });
+      if (ok) {
+        setPickedIssues(prev =>
+          prev.map(s => (s.id === issueId ? { ...s, userTags: tags } : s)),
+        );
+      }
+    },
+    [userId],
+  );
+
   // Check current state of all picked issues via GitHub API
   const refreshPickedIssues = useCallback(async (): Promise<StateChange[]> => {
-    if (settings.pickedIssues.length === 0) return [];
+    if (pickedIssues.length === 0 || !userId) return [];
 
     setLoading(true);
     setError(null);
@@ -44,7 +149,7 @@ const usePickedIssues = (
       const octokit = new Octokit(accessToken ? { auth: accessToken } : undefined);
 
       const updated = await batchProcess(
-        settings.pickedIssues,
+        pickedIssues,
         async (picked: PickedIssue) => {
           try {
             const { data } = await octokit.issues.get({
@@ -89,8 +194,9 @@ const usePickedIssues = (
         5,
       );
 
-      // Persist via useSettings (localStorage + Supabase)
-      await persistSettings({ ...settings, pickedIssues: updated });
+      // Persist updated issues to Supabase
+      await bulkUpdatePickedIssues(userId, updated);
+      setPickedIssues(updated);
     } catch (err) {
       console.error('Error refreshing picked issues:', err);
       setError('Failed to check picked issue states');
@@ -99,12 +205,15 @@ const usePickedIssues = (
     }
 
     return changes;
-  }, [settings, persistSettings, accessToken]);
+  }, [pickedIssues, userId, accessToken]);
 
   return {
-    pickedIssues: settings.pickedIssues,
+    pickedIssues,
     loading,
     error,
+    pickIssue,
+    unpickIssue,
+    updateIssueTags,
     refreshPickedIssues,
   };
 };

--- a/app/hooks/useSettings.ts
+++ b/app/hooks/useSettings.ts
@@ -1,12 +1,12 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { UserSettings, Issue, PickedIssue } from '../types';
+import { UserSettings } from '../types';
 import { saveSettings, loadSettings, defaultSettings } from '../utils/localStorage';
 import {
   loadUserSettings as loadFromSupabase,
   saveUserSettings as saveToSupabase,
 } from '../lib/supabase/settings';
 
-// Custom hook for managing user settings
+// Custom hook for managing user settings (no longer manages picked issues)
 const useSettings = (isLoggedIn: boolean, userId?: string) => {
   const [settings, setSettings] = useState<UserSettings>(defaultSettings);
   const [loading, setLoading] = useState<boolean>(true);
@@ -77,76 +77,6 @@ const useSettings = (isLoggedIn: boolean, userId?: string) => {
     [isLoggedIn, userId],
   );
 
-  // Save (pick) an issue
-  const pickIssue = useCallback(
-    async (issue: Issue): Promise<boolean> => {
-      try {
-        const alreadySaved = settings.pickedIssues.some(s => s.id === issue.id);
-        if (alreadySaved) return false;
-
-        const now = new Date().toISOString();
-        const saved: PickedIssue = {
-          id: issue.id,
-          number: issue.number,
-          title: issue.title,
-          url: issue.url,
-          state: issue.state,
-          repository: {
-            owner: issue.repository.owner,
-            name: issue.repository.name,
-          },
-          labels: issue.labels,
-          savedAt: now,
-          userTags: [],
-          lastKnownState: issue.state,
-          lastCheckedAt: now,
-          assignee: undefined,
-        };
-
-        const newSettings = {
-          ...settings,
-          pickedIssues: [...settings.pickedIssues, saved],
-        };
-
-        await saveUserSettings(newSettings);
-        return true;
-      } catch (err) {
-        console.error('Error saving issue:', err);
-        setError('Failed to save issue');
-        return false;
-      }
-    },
-    [settings, saveUserSettings],
-  );
-
-  // Unsave (unpick) an issue
-  const unpickIssue = useCallback(
-    async (issueId: string): Promise<void> => {
-      const newSettings = {
-        ...settings,
-        pickedIssues: settings.pickedIssues.filter(s => s.id !== issueId),
-      };
-
-      await saveUserSettings(newSettings);
-    },
-    [settings, saveUserSettings],
-  );
-
-  // Update user tags on a saved issue
-  const updateIssueTags = useCallback(
-    async (issueId: string, tags: string[]): Promise<void> => {
-      const newSettings = {
-        ...settings,
-        pickedIssues: settings.pickedIssues.map(s =>
-          s.id === issueId ? { ...s, userTags: tags } : s,
-        ),
-      };
-
-      await saveUserSettings(newSettings);
-    },
-    [settings, saveUserSettings],
-  );
-
   // Update notification frequency
   const updateNotificationFrequency = useCallback(
     async (frequency: 'hourly' | '6hours' | 'daily' | 'never'): Promise<boolean> => {
@@ -211,9 +141,6 @@ const useSettings = (isLoggedIn: boolean, userId?: string) => {
     settings,
     loading,
     error,
-    pickIssue,
-    unpickIssue,
-    updateIssueTags,
     updateNotificationFrequency,
     toggleHideClosedIssues,
     updateLastCheckedAt,

--- a/app/lib/supabase/pickedIssues.ts
+++ b/app/lib/supabase/pickedIssues.ts
@@ -56,7 +56,9 @@ export async function pickIssue(userId: string, issue: PickedIssue): Promise<boo
     last_checked_at: issue.lastCheckedAt,
   };
 
-  const { error } = await supabase.from('picked_issues').upsert(row as never);
+  const { error } = await supabase
+    .from('picked_issues')
+    .upsert(row as never, { onConflict: 'user_id,issue_id' });
   return !error;
 }
 
@@ -120,7 +122,9 @@ export async function bulkUpdatePickedIssues(
       }) satisfies PickedIssueInsert,
   );
 
-  const { error } = await supabase.from('picked_issues').upsert(rows as never);
+  const { error } = await supabase
+    .from('picked_issues')
+    .upsert(rows as never, { onConflict: 'user_id,issue_id' });
   return !error;
 }
 

--- a/app/lib/supabase/pickedIssues.ts
+++ b/app/lib/supabase/pickedIssues.ts
@@ -1,0 +1,158 @@
+import { createClient } from '@/app/lib/supabase/client';
+import { PickedIssue, Label } from '@/app/types';
+import { Database } from '@/app/types/supabase';
+
+type PickedIssueRow = Database['public']['Tables']['picked_issues']['Row'];
+type PickedIssueInsert = Database['public']['Tables']['picked_issues']['Insert'];
+
+function rowToPickedIssue(row: PickedIssueRow): PickedIssue {
+  return {
+    id: row.issue_id,
+    number: row.issue_number,
+    title: row.title,
+    url: row.issue_url,
+    state: row.state as 'open' | 'closed',
+    repository: {
+      owner: row.repository_owner,
+      name: row.repository_name,
+    },
+    labels: (row.labels as unknown as Label[]) ?? [],
+    savedAt: row.picked_at,
+    userTags: (row.user_tags as unknown as string[]) ?? [],
+    lastKnownState: row.last_known_state as 'open' | 'closed',
+    lastCheckedAt: row.last_checked_at,
+    assignee: row.assignee ?? undefined,
+  };
+}
+
+export async function loadPickedIssues(userId: string): Promise<PickedIssue[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('picked_issues')
+    .select('*')
+    .eq('user_id', userId)
+    .order('picked_at', { ascending: false });
+
+  if (error || !data) return [];
+  return (data as unknown as PickedIssueRow[]).map(rowToPickedIssue);
+}
+
+export async function pickIssue(userId: string, issue: PickedIssue): Promise<boolean> {
+  const supabase = createClient();
+  const row: PickedIssueInsert = {
+    user_id: userId,
+    issue_id: issue.id,
+    issue_number: issue.number,
+    issue_url: issue.url,
+    repository_owner: issue.repository.owner,
+    repository_name: issue.repository.name,
+    title: issue.title,
+    state: issue.state,
+    labels: issue.labels as unknown as PickedIssueInsert['labels'],
+    assignee: issue.assignee ?? null,
+    user_tags: issue.userTags as unknown as PickedIssueInsert['user_tags'],
+    picked_at: issue.savedAt,
+    last_known_state: issue.lastKnownState,
+    last_checked_at: issue.lastCheckedAt,
+  };
+
+  const { error } = await supabase.from('picked_issues').upsert(row as never);
+  return !error;
+}
+
+export async function unpickIssue(userId: string, issueId: string): Promise<boolean> {
+  const supabase = createClient();
+  const { error } = await supabase
+    .from('picked_issues')
+    .delete()
+    .eq('user_id', userId)
+    .eq('issue_id', issueId);
+  return !error;
+}
+
+export async function updatePickedIssue(
+  userId: string,
+  issueId: string,
+  updates: Partial<
+    Pick<
+      PickedIssueRow,
+      | 'title'
+      | 'state'
+      | 'labels'
+      | 'assignee'
+      | 'user_tags'
+      | 'last_known_state'
+      | 'last_checked_at'
+    >
+  >,
+): Promise<boolean> {
+  const supabase = createClient();
+  const { error } = await supabase
+    .from('picked_issues')
+    .update(updates as never)
+    .eq('user_id', userId)
+    .eq('issue_id', issueId);
+  return !error;
+}
+
+export async function bulkUpdatePickedIssues(
+  userId: string,
+  issues: PickedIssue[],
+): Promise<boolean> {
+  const supabase = createClient();
+  const rows = issues.map(
+    issue =>
+      ({
+        user_id: userId,
+        issue_id: issue.id,
+        issue_number: issue.number,
+        issue_url: issue.url,
+        repository_owner: issue.repository.owner,
+        repository_name: issue.repository.name,
+        title: issue.title,
+        state: issue.state,
+        labels: issue.labels as unknown as PickedIssueInsert['labels'],
+        assignee: issue.assignee ?? null,
+        user_tags: issue.userTags as unknown as PickedIssueInsert['user_tags'],
+        picked_at: issue.savedAt,
+        last_known_state: issue.lastKnownState,
+        last_checked_at: issue.lastCheckedAt,
+      }) satisfies PickedIssueInsert,
+  );
+
+  const { error } = await supabase.from('picked_issues').upsert(rows as never);
+  return !error;
+}
+
+export interface PickCount {
+  issueUrl: string;
+  repositoryOwner: string;
+  repositoryName: string;
+  title: string;
+  pickCount: number;
+}
+
+export async function getPickCounts(): Promise<PickCount[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('picked_issues_counts' as never)
+    .select('*');
+
+  if (error || !data) return [];
+
+  return (
+    data as unknown as Array<{
+      issue_url: string;
+      repository_owner: string;
+      repository_name: string;
+      title: string;
+      pick_count: number;
+    }>
+  ).map(row => ({
+    issueUrl: row.issue_url,
+    repositoryOwner: row.repository_owner,
+    repositoryName: row.repository_name,
+    title: row.title,
+    pickCount: row.pick_count,
+  }));
+}

--- a/app/lib/supabase/settings.ts
+++ b/app/lib/supabase/settings.ts
@@ -16,7 +16,7 @@ export async function loadUserSettings(userId: string): Promise<UserSettings | n
   if (error || !data) return null;
 
   return {
-    pickedIssues: (data.picked_issues as unknown as UserSettings['pickedIssues']) ?? [],
+    pickedIssues: [],
     notificationFrequency:
       (data.notification_frequency as UserSettings['notificationFrequency']) ?? 'daily',
     hideClosedIssues: data.hide_closed_issues ?? true,
@@ -30,8 +30,6 @@ export async function saveUserSettings(
   const supabase = createClient();
   const row: UserSettingsInsert = {
     user_id: userId,
-    picked_issues:
-      settings.pickedIssues as unknown as UserSettingsInsert['picked_issues'],
     notification_frequency: settings.notificationFrequency,
     hide_closed_issues: settings.hideClosedIssues,
     updated_at: new Date().toISOString(),

--- a/app/types/supabase.ts
+++ b/app/types/supabase.ts
@@ -64,8 +64,71 @@ export interface Database {
           updated_at?: string;
         };
       };
+      picked_issues: {
+        Row: {
+          id: string;
+          user_id: string;
+          issue_id: string;
+          issue_number: number;
+          issue_url: string;
+          repository_owner: string;
+          repository_name: string;
+          title: string;
+          state: string;
+          labels: Json;
+          assignee: string | null;
+          user_tags: Json;
+          picked_at: string;
+          last_known_state: string;
+          last_checked_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          issue_id: string;
+          issue_number: number;
+          issue_url: string;
+          repository_owner: string;
+          repository_name: string;
+          title: string;
+          state?: string;
+          labels?: Json;
+          assignee?: string | null;
+          user_tags?: Json;
+          picked_at?: string;
+          last_known_state?: string;
+          last_checked_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          issue_id?: string;
+          issue_number?: number;
+          issue_url?: string;
+          repository_owner?: string;
+          repository_name?: string;
+          title?: string;
+          state?: string;
+          labels?: Json;
+          assignee?: string | null;
+          user_tags?: Json;
+          picked_at?: string;
+          last_known_state?: string;
+          last_checked_at?: string;
+        };
+      };
     };
-    Views: Record<string, never>;
+    Views: {
+      picked_issues_counts: {
+        Row: {
+          issue_url: string;
+          repository_owner: string;
+          repository_name: string;
+          title: string;
+          pick_count: number;
+        };
+      };
+    };
     Functions: Record<string, never>;
     Enums: Record<string, never>;
   };

--- a/supabase/migrations/004_create_picked_issues_table.sql
+++ b/supabase/migrations/004_create_picked_issues_table.sql
@@ -1,0 +1,63 @@
+-- Create picked_issues table (normalized from user_settings JSON blob)
+create table picked_issues (
+  id uuid primary key default gen_random_uuid(),
+  user_id text not null references user_profiles(id) on delete cascade,
+  issue_id text not null,            -- GitHub issue node ID
+  issue_number int not null,
+  issue_url text not null,
+  repository_owner text not null,
+  repository_name text not null,
+  title text not null,
+  state text not null default 'open',
+  labels jsonb default '[]',
+  assignee text,
+  user_tags jsonb default '[]',
+  picked_at timestamptz default now(),
+  last_known_state text not null default 'open',
+  last_checked_at timestamptz default now()
+);
+
+-- Indexes
+create index idx_picked_issues_user_id on picked_issues(user_id);
+create index idx_picked_issues_issue_url on picked_issues(issue_url);
+create index idx_picked_issues_repo on picked_issues(repository_owner, repository_name);
+
+-- Unique constraint: a user can only pick the same issue once
+create unique index idx_picked_issues_user_issue on picked_issues(user_id, issue_id);
+
+-- RLS
+alter table picked_issues enable row level security;
+
+-- Users can read their own picked issues
+create policy "Users can view own picked issues"
+  on picked_issues for select
+  using (auth.uid()::text = user_id);
+
+-- Users can insert their own picked issues
+create policy "Users can insert own picked issues"
+  on picked_issues for insert
+  with check (auth.uid()::text = user_id);
+
+-- Users can update their own picked issues
+create policy "Users can update own picked issues"
+  on picked_issues for update
+  using (auth.uid()::text = user_id);
+
+-- Users can delete their own picked issues
+create policy "Users can delete own picked issues"
+  on picked_issues for delete
+  using (auth.uid()::text = user_id);
+
+-- Aggregate view: pick counts per issue_url (cross-user, public)
+create view picked_issues_counts as
+  select
+    issue_url,
+    repository_owner,
+    repository_name,
+    title,
+    count(*) as pick_count
+  from picked_issues
+  group by issue_url, repository_owner, repository_name, title;
+
+-- Allow all authenticated users to read aggregate counts
+grant select on picked_issues_counts to authenticated;

--- a/supabase/migrations/004_create_picked_issues_table.sql
+++ b/supabase/migrations/004_create_picked_issues_table.sql
@@ -54,10 +54,10 @@ create view picked_issues_counts as
     issue_url,
     repository_owner,
     repository_name,
-    title,
+    max(title) as title,
     count(*) as pick_count
   from picked_issues
-  group by issue_url, repository_owner, repository_name, title;
+  group by issue_url, repository_owner, repository_name;
 
 -- Allow all authenticated users to read aggregate counts
 grant select on picked_issues_counts to authenticated;

--- a/supabase/migrations/005_migrate_picked_issues_data.sql
+++ b/supabase/migrations/005_migrate_picked_issues_data.sql
@@ -1,0 +1,36 @@
+-- Migrate existing picked_issues JSON blob from user_settings into the new table
+insert into picked_issues (
+  user_id,
+  issue_id,
+  issue_number,
+  issue_url,
+  repository_owner,
+  repository_name,
+  title,
+  state,
+  labels,
+  assignee,
+  user_tags,
+  picked_at,
+  last_known_state,
+  last_checked_at
+)
+select
+  us.user_id,
+  pi->>'id',
+  (pi->>'number')::int,
+  pi->>'url',
+  pi->'repository'->>'owner',
+  pi->'repository'->>'name',
+  pi->>'title',
+  coalesce(pi->>'state', 'open'),
+  coalesce(pi->'labels', '[]'::jsonb),
+  pi->>'assignee',
+  coalesce(pi->'userTags', '[]'::jsonb),
+  coalesce((pi->>'savedAt')::timestamptz, now()),
+  coalesce(pi->>'lastKnownState', 'open'),
+  coalesce((pi->>'lastCheckedAt')::timestamptz, now())
+from user_settings us,
+  jsonb_array_elements(us.picked_issues) as pi
+where jsonb_array_length(us.picked_issues) > 0
+on conflict (user_id, (pi->>'id')) do nothing;

--- a/supabase/migrations/005_migrate_picked_issues_data.sql
+++ b/supabase/migrations/005_migrate_picked_issues_data.sql
@@ -33,4 +33,4 @@ select
 from user_settings us,
   jsonb_array_elements(us.picked_issues) as pi
 where jsonb_array_length(us.picked_issues) > 0
-on conflict (user_id, (pi->>'id')) do nothing;
+on conflict (user_id, issue_id) do nothing;


### PR DESCRIPTION
## Summary
- `picked_issues`를 `user_settings` JSON 컬럼에서 별도 Supabase 테이블로 분리
- RLS 정책 설정 (본인 CRUD + 집계 쿼리용 SELECT)
- `usePickedIssues` 훅을 독립 상태 관리로 리팩토링, `useSettings` 의존성 제거
- 집계 뷰 `picked_issues_counts` 생성으로 cross-user 쿼리 지원

Closes #54

## Changes
- `supabase/migrations/004_create_picked_issues_table.sql` — 테이블, 인덱스, RLS, 집계 뷰
- `supabase/migrations/005_migrate_picked_issues_data.sql` — JSON blob → 새 테이블 마이그레이션
- `app/lib/supabase/pickedIssues.ts` — CRUD 함수 (load, pick, unpick, update, bulk, getPickCounts)
- `app/hooks/usePickedIssues.ts` — Supabase 직접 연동으로 리팩토링
- `app/hooks/useSettings.ts` — picked issues 관련 코드 제거
- `app/lib/supabase/settings.ts` — picked_issues 컬럼 읽기/쓰기 제거
- `app/types/supabase.ts` — picked_issues 테이블 + 뷰 타입 추가
- `app/contexts/AppContext.tsx` — 리팩토링된 훅 연결
- `app/components/RecommendedIssues.tsx` — context에서 pickedIssues 직접 참조

## Test plan
- [ ] Supabase 마이그레이션 실행 후 `picked_issues` 테이블 생성 확인
- [ ] pick/unpick 동작 확인 (새 테이블에 저장됨)
- [ ] 기존 JSON blob 데이터가 새 테이블로 정상 마이그레이션됨
- [ ] `picked_issues_counts` 뷰로 집계 쿼리 동작 확인
- [ ] 비로그인 상태에서 에러 없이 빈 목록 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)