### PR TITLE
feat: Weekly Picks 자동 생성 페이지

### DIFF
--- a/app/lib/weeklyPicks.ts
+++ b/app/lib/weeklyPicks.ts
@@ -16,13 +16,16 @@ const getFreshnessDate = (freshness: '1w' | '1m'): string => {
   return now.toISOString().split('T')[0];
 };
 
-const getWeekNumber = (date: Date): number => {
+export const getIsoWeekAndYear = (date: Date): { weekNumber: number; year: number } => {
   const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
   const dayNum = d.getUTCDay() || 7;
   d.setUTCDate(d.getUTCDate() + 4 - dayNum);
   const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-  return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  const weekNumber = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return { weekNumber, year: d.getUTCFullYear() };
 };
+
+export const getWeekNumber = (date: Date): number => getIsoWeekAndYear(date).weekNumber;
 
 export interface WeeklyPicksData {
   issues: Issue[];
@@ -132,8 +135,7 @@ async function fetchIssuesFromGitHub(
 
 export async function getWeeklyPicks(): Promise<WeeklyPicksData> {
   const now = new Date();
-  const weekNumber = getWeekNumber(now);
-  const year = now.getFullYear();
+  const { weekNumber, year } = getIsoWeekAndYear(now);
   const weekCacheKey = `${CACHE_KEY}:${year}-W${weekNumber}`;
 
   const cached = await cacheGet<WeeklyPicksData>(weekCacheKey);

--- a/app/lib/weeklyPicks.ts
+++ b/app/lib/weeklyPicks.ts
@@ -1,0 +1,159 @@
+import { Issue, Label, Repository } from '../types';
+import { getServerOctokit } from '../api/recommended/serverOctokit';
+import { calculateMaintainerScore } from '../api/recommended/maintainerScore';
+import { cacheGet, cacheSet } from './cache';
+
+const CACHE_KEY = 'weekly-picks';
+const CACHE_TTL_SECONDS = 604800; // 1 week
+
+const getFreshnessDate = (freshness: '1w' | '1m'): string => {
+  const now = new Date();
+  if (freshness === '1w') {
+    now.setDate(now.getDate() - 7);
+  } else {
+    now.setMonth(now.getMonth() - 1);
+  }
+  return now.toISOString().split('T')[0];
+};
+
+const getWeekNumber = (date: Date): number => {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+};
+
+export interface WeeklyPicksData {
+  issues: Issue[];
+  weekNumber: number;
+  year: number;
+  generatedAt: string;
+}
+
+async function fetchIssuesFromGitHub(
+  freshness: '1w' | '1m',
+  limit: number,
+): Promise<Issue[]> {
+  const dateStr = getFreshnessDate(freshness);
+  const query = `is:issue is:open label:"good first issue" stars:>500 pushed:>${dateStr}`;
+
+  const octokit = await getServerOctokit();
+
+  const { data } = await octokit.search.issuesAndPullRequests({
+    q: query,
+    sort: 'reactions',
+    order: 'desc',
+    per_page: limit,
+  });
+
+  const issues = await Promise.all(
+    data.items.map(async item => {
+      const repoUrl = item.repository_url;
+      const parts = repoUrl.split('/');
+      const repoName = parts[parts.length - 1];
+      const repoOwner = parts[parts.length - 2];
+
+      const maintainerScore = await calculateMaintainerScore(repoOwner, repoName);
+
+      let stargazersCount: number | undefined;
+      let forksCount: number | undefined;
+      let repoLanguage: string | undefined;
+      let lastPushedAt: string | undefined;
+      let description: string | undefined;
+      try {
+        const { data: repoData } = await octokit.repos.get({
+          owner: repoOwner,
+          repo: repoName,
+        });
+        stargazersCount = repoData.stargazers_count;
+        forksCount = repoData.forks_count;
+        repoLanguage = repoData.language ?? undefined;
+        lastPushedAt = repoData.pushed_at ?? undefined;
+        description = repoData.description ?? undefined;
+      } catch {
+        // Continue without repo metadata
+      }
+
+      const repository: Repository = {
+        id: `${repoOwner}/${repoName}`,
+        owner: repoOwner,
+        name: repoName,
+        url: `https://github.com/${repoOwner}/${repoName}`,
+        description,
+        stargazersCount,
+        forksCount,
+        language: repoLanguage,
+        lastPushedAt,
+        maintainerScore,
+      };
+
+      const labels: Label[] = item.labels
+        .filter(
+          (
+            l,
+          ): l is {
+            id: number;
+            name: string;
+            color: string;
+            description: string | null;
+            default: boolean;
+            node_id: string;
+            url: string;
+          } => typeof l === 'object' && l !== null && 'name' in l,
+        )
+        .map(l => ({
+          id: String(l.id ?? ''),
+          name: l.name ?? '',
+          color: l.color ?? '',
+        }));
+
+      const issue: Issue = {
+        id: String(item.id),
+        number: item.number,
+        title: item.title,
+        url: item.html_url,
+        body: item.body ?? undefined,
+        labels,
+        createdAt: item.created_at,
+        updatedAt: item.updated_at,
+        state: item.state as 'open' | 'closed',
+        repository,
+        comments: item.comments,
+        assignee: item.assignee?.login ?? null,
+      };
+
+      return issue;
+    }),
+  );
+
+  return issues;
+}
+
+export async function getWeeklyPicks(): Promise<WeeklyPicksData> {
+  const now = new Date();
+  const weekNumber = getWeekNumber(now);
+  const year = now.getFullYear();
+  const weekCacheKey = `${CACHE_KEY}:${year}-W${weekNumber}`;
+
+  const cached = await cacheGet<WeeklyPicksData>(weekCacheKey);
+  if (cached) return cached;
+
+  let issues = await fetchIssuesFromGitHub('1w', 10);
+
+  // Fallback: if fewer than 5 issues, relax to 1 month freshness
+  if (issues.length < 5) {
+    issues = await fetchIssuesFromGitHub('1m', 10);
+  }
+
+  const result: WeeklyPicksData = {
+    issues,
+    weekNumber,
+    year,
+    generatedAt: now.toISOString(),
+  };
+
+  await cacheSet(weekCacheKey, result, CACHE_TTL_SECONDS);
+
+  return result;
+}

--- a/app/weekly-picks/WeeklyPicksClient.tsx
+++ b/app/weekly-picks/WeeklyPicksClient.tsx
@@ -160,6 +160,7 @@ interface WeeklyPicksClientProps {
 
 export default function WeeklyPicksClient({ data }: WeeklyPicksClientProps) {
   const t = useTranslations('weeklyPicks');
+  const { locale } = useLocaleSwitch();
 
   return (
     <div className="min-h-screen bg-background">
@@ -178,7 +179,9 @@ export default function WeeklyPicksClient({ data }: WeeklyPicksClientProps) {
           </p>
           <p className="text-muted-foreground/60 text-xs mt-1">
             {t('generatedAt', {
-              date: new Date(data.generatedAt).toLocaleDateString(),
+              date: new Intl.DateTimeFormat(locale === 'ko' ? 'ko-KR' : 'en-US').format(
+                new Date(data.generatedAt),
+              ),
             })}
           </p>
         </div>

--- a/app/weekly-picks/WeeklyPicksClient.tsx
+++ b/app/weekly-picks/WeeklyPicksClient.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import React from 'react';
+import { FaStar, FaCodeBranch, FaCalendarWeek } from 'react-icons/fa';
+import { LuShield, LuCircleDot, LuUsers, LuFlame } from 'react-icons/lu';
+import { useTranslations } from 'next-intl';
+import { useLocaleSwitch } from '@/app/providers/IntlProvider';
+import type { WeeklyPicksData } from '../lib/weeklyPicks';
+import type { Issue } from '../types';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+type CompetitionStatus = 'available' | 'inProgress' | 'hot';
+
+const getCompetitionStatus = (
+  comments: number | undefined,
+  assignee: string | null | undefined,
+): CompetitionStatus => {
+  if (assignee) return 'inProgress';
+  if ((comments ?? 0) >= 3) return 'hot';
+  return 'available';
+};
+
+const competitionStatusStyles: Record<CompetitionStatus, string> = {
+  available: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
+  inProgress: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
+  hot: 'bg-red-500/15 text-red-400 border-red-500/20',
+};
+
+const competitionStatusIcons: Record<CompetitionStatus, React.ReactNode> = {
+  available: <LuCircleDot className="shrink-0 size-2.5" />,
+  inProgress: <LuUsers className="shrink-0 size-2.5" />,
+  hot: <LuFlame className="shrink-0 size-2.5" />,
+};
+
+const maintainerGradeStyles: Record<string, string> = {
+  A: 'bg-emerald-500/15 text-emerald-400',
+  B: 'bg-amber-500/15 text-amber-400',
+  C: 'bg-muted text-muted-foreground',
+};
+
+const formatRelativeTime = (
+  dateString: string,
+  tCommon: ReturnType<typeof useTranslations<'common'>>,
+  locale: string,
+): string => {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffInMs = now.getTime() - date.getTime();
+  const diffInHours = Math.floor(diffInMs / (1000 * 60 * 60));
+  const diffInDays = Math.floor(diffInHours / 24);
+
+  if (diffInHours < 1) return tCommon('justNow');
+  if (diffInHours < 24) return tCommon('hoursAgo', { hours: diffInHours });
+  if (diffInDays < 30) return tCommon('daysAgo', { days: diffInDays });
+  return new Intl.DateTimeFormat(locale === 'ko' ? 'ko-KR' : 'en-US').format(date);
+};
+
+function WeeklyIssueCard({ issue, rank }: { issue: Issue; rank: number }) {
+  const tCommon = useTranslations('common');
+  const tMaintainer = useTranslations('maintainer');
+  const tIssue = useTranslations('issue');
+  const { locale } = useLocaleSwitch();
+
+  const competitionStatus = getCompetitionStatus(issue.comments, issue.assignee);
+
+  return (
+    <Card className="rounded-lg border-border p-4 hover:border-primary/30 transition-colors gap-0">
+      <div className="flex items-start gap-4">
+        <div className="flex-shrink-0 flex items-center justify-center w-8 h-8 rounded-full bg-primary/10 text-primary font-bold text-sm">
+          {rank}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="text-base font-semibold text-foreground">
+              <a
+                href={issue.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:text-primary transition-colors"
+              >
+                {issue.title}
+              </a>
+            </h3>
+            {issue.repository.maintainerScore && (
+              <Badge
+                variant="outline"
+                className={cn(
+                  'inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded border-none',
+                  maintainerGradeStyles[issue.repository.maintainerScore.grade],
+                )}
+                title={`${tMaintainer(`grade${issue.repository.maintainerScore.grade}`)} · ${tMaintainer('responseTime', { hours: Math.round(issue.repository.maintainerScore.avgResponseTimeHours) })} · ${tMaintainer('mergeRate', { rate: Math.round(issue.repository.maintainerScore.mergeRate * 100) })}`}
+              >
+                <LuShield className="shrink-0 size-[11px]" />
+                {tMaintainer(`grade${issue.repository.maintainerScore.grade}`)}
+              </Badge>
+            )}
+            <Badge
+              variant="outline"
+              className={cn(
+                'inline-flex items-center gap-1 text-xs py-0.5 px-2 rounded font-medium',
+                competitionStatusStyles[competitionStatus],
+              )}
+            >
+              {competitionStatusIcons[competitionStatus]}
+              {tIssue(`status.${competitionStatus}`)}
+            </Badge>
+          </div>
+
+          <div className="flex flex-wrap gap-1.5 mt-2">
+            {issue.labels.map(label => (
+              <Badge
+                key={label.id}
+                variant="outline"
+                className="text-xs px-2 py-0.5 rounded-full border-none"
+                style={{
+                  backgroundColor: `#${label.color}25`,
+                  color: `#${label.color}`,
+                  border: `1px solid #${label.color}50`,
+                }}
+              >
+                {label.name}
+              </Badge>
+            ))}
+          </div>
+
+          <div className="flex items-center mt-3 text-sm text-muted-foreground flex-wrap gap-y-1 gap-x-3">
+            <span className="font-mono text-xs text-foreground/70">
+              {issue.repository.owner}/{issue.repository.name} #{issue.number}
+            </span>
+            {issue.repository.stargazersCount !== undefined && (
+              <span className="inline-flex items-center gap-1 text-xs">
+                <FaStar className="text-amber-400/70 text-[10px]" />
+                {issue.repository.stargazersCount.toLocaleString()}
+              </span>
+            )}
+            {issue.repository.forksCount !== undefined && (
+              <span className="inline-flex items-center gap-1 text-xs">
+                <FaCodeBranch className="text-[10px]" />
+                {issue.repository.forksCount.toLocaleString()}
+              </span>
+            )}
+            {issue.repository.language && (
+              <span className="text-xs">{issue.repository.language}</span>
+            )}
+            <span className="text-xs">
+              {formatRelativeTime(issue.createdAt, tCommon, locale)}
+            </span>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+interface WeeklyPicksClientProps {
+  data: WeeklyPicksData;
+}
+
+export default function WeeklyPicksClient({ data }: WeeklyPicksClientProps) {
+  const t = useTranslations('weeklyPicks');
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-3xl mx-auto px-4 py-8">
+        {/* Header */}
+        <div className="mb-8">
+          <div className="flex items-center gap-3 mb-2">
+            <FaCalendarWeek className="text-primary text-xl" />
+            <h1 className="text-2xl font-bold text-foreground">{t('title')}</h1>
+          </div>
+          <p className="text-muted-foreground text-sm">
+            {t('subtitle', {
+              week: data.weekNumber,
+              year: data.year,
+            })}
+          </p>
+          <p className="text-muted-foreground/60 text-xs mt-1">
+            {t('generatedAt', {
+              date: new Date(data.generatedAt).toLocaleDateString(),
+            })}
+          </p>
+        </div>
+
+        {/* Issue list */}
+        {data.issues.length === 0 ? (
+          <div className="text-center py-12 text-muted-foreground">{t('noIssues')}</div>
+        ) : (
+          <div className="space-y-3">
+            {data.issues.map((issue, idx) => (
+              <WeeklyIssueCard key={issue.id} issue={issue} rank={idx + 1} />
+            ))}
+          </div>
+        )}
+
+        {/* Footer note */}
+        <div className="mt-8 text-center text-xs text-muted-foreground/60">
+          {t('autoRefresh')}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/weekly-picks/page.tsx
+++ b/app/weekly-picks/page.tsx
@@ -1,0 +1,86 @@
+import type { Metadata } from 'next';
+import { getWeeklyPicks } from '../lib/weeklyPicks';
+import WeeklyPicksClient from './WeeklyPicksClient';
+
+export const revalidate = 604800; // 1 week in seconds
+
+export async function generateMetadata(): Promise<Metadata> {
+  const now = new Date();
+  const d = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const weekNumber = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  const year = now.getFullYear();
+
+  const title = `Weekly Picks - Week ${weekNumber}, ${year}`;
+  const description = `Top 10 beginner-friendly open source issues curated for Week ${weekNumber}, ${year}. Find your next contribution on Pickssue.`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: '/weekly-picks',
+      siteName: 'Pickssue',
+      type: 'website',
+      images: [
+        {
+          url: '/og-image.png',
+          width: 1200,
+          height: 630,
+          alt: 'Pickssue Weekly Picks',
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: ['/og-image.png'],
+    },
+  };
+}
+
+export default async function WeeklyPicksPage() {
+  const data = await getWeeklyPicks();
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: `Pickssue Weekly Picks - Week ${data.weekNumber}, ${data.year}`,
+    description: `Top 10 beginner-friendly open source issues curated for Week ${data.weekNumber}, ${data.year}.`,
+    url: 'https://pickssue.dev/weekly-picks',
+    isPartOf: {
+      '@type': 'WebSite',
+      name: 'Pickssue',
+      url: 'https://pickssue.dev',
+    },
+    datePublished: data.generatedAt,
+    mainEntity: {
+      '@type': 'ItemList',
+      numberOfItems: data.issues.length,
+      itemListElement: data.issues.map((issue, idx) => ({
+        '@type': 'ListItem',
+        position: idx + 1,
+        item: {
+          '@type': 'SoftwareSourceCode',
+          name: issue.title,
+          url: issue.url,
+          codeRepository: issue.repository.url,
+        },
+      })),
+    },
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <WeeklyPicksClient data={data} />
+    </>
+  );
+}

--- a/app/weekly-picks/page.tsx
+++ b/app/weekly-picks/page.tsx
@@ -1,17 +1,11 @@
 import type { Metadata } from 'next';
-import { getWeeklyPicks } from '../lib/weeklyPicks';
+import { getWeeklyPicks, getIsoWeekAndYear } from '../lib/weeklyPicks';
 import WeeklyPicksClient from './WeeklyPicksClient';
 
 export const revalidate = 604800; // 1 week in seconds
 
 export async function generateMetadata(): Promise<Metadata> {
-  const now = new Date();
-  const d = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
-  const dayNum = d.getUTCDay() || 7;
-  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
-  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-  const weekNumber = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
-  const year = now.getFullYear();
+  const { weekNumber, year } = getIsoWeekAndYear(new Date());
 
   const title = `Weekly Picks - Week ${weekNumber}, ${year}`;
   const description = `Top 10 beginner-friendly open source issues curated for Week ${weekNumber}, ${year}. Find your next contribution on Pickssue.`;

--- a/messages/en.json
+++ b/messages/en.json
@@ -278,6 +278,13 @@
     "rateLimitExceeded": "GitHub API rate limit reached. Please try again later or log in for higher limits.",
     "rateLimitExceededLoggedIn": "GitHub API rate limit reached. Please try again later."
   },
+  "weeklyPicks": {
+    "title": "Weekly Picks",
+    "subtitle": "Top beginner-friendly issues for Week {week}, {year}",
+    "generatedAt": "Generated on {date}",
+    "noIssues": "No weekly picks available yet. Check back soon!",
+    "autoRefresh": "This page is automatically refreshed every week with fresh picks."
+  },
   "sync": {
     "localRepositories": "Local Repositories",
     "gistRepositories": "Cloud Repositories",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -278,6 +278,13 @@
     "rateLimitExceeded": "GitHub API 요청 한도에 도달했습니다. 잠시 후 다시 시도하거나 로그인하여 한도를 늘려보세요.",
     "rateLimitExceededLoggedIn": "GitHub API 요청 한도에 도달했습니다. 잠시 후 다시 시도해주세요."
   },
+  "weeklyPicks": {
+    "title": "주간 추천",
+    "subtitle": "{year}년 {week}주차 추천 이슈",
+    "generatedAt": "생성일: {date}",
+    "noIssues": "아직 주간 추천이 없습니다. 곧 업데이트됩니다!",
+    "autoRefresh": "이 페이지는 매주 자동으로 새로운 추천 이슈로 갱신됩니다."
+  },
   "sync": {
     "localRepositories": "로컬 저장소",
     "gistRepositories": "클라우드 저장소",


### PR DESCRIPTION
## Summary
- 기존 `/api/recommended` 데이터 기반 주간 큐레이션 페이지 생성
- Next.js ISR로 주간 자동 갱신 (revalidate 604800초)
- SSR + SEO 메타데이터 + JSON-LD 구조화 데이터
- fallback: 이슈 5개 미만 시 freshness 1개월로 완화

Closes #36

## Changes
- `app/lib/weeklyPicks.ts` — 서버사이드 데이터 fetching + 캐시 + fallback
- `app/weekly-picks/page.tsx` — SSR + ISR 페이지, 동적 SEO 메타데이터, JSON-LD
- `app/weekly-picks/WeeklyPicksClient.tsx` — DaisyUI 카드형 레이아웃, 주차 정보
- `messages/en.json` / `messages/ko.json` — weeklyPicks i18n 키 추가

## Test plan
- [ ] `/weekly-picks` 페이지 SSR 렌더링 확인
- [ ] 최소 5개 이상 이슈 항상 표시 (fallback 동작)
- [ ] SEO 메타데이터 (title, description, OG) 주차별 동적 생성 확인
- [ ] JSON-LD 구조화 데이터 확인
- [ ] i18n EN/KO 전환 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)