### PR TITLE
feat: 이슈 품질 스코어 (A/B/C 등급) 도입

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+#!/bin/sh
 npx lint-staged

--- a/app/api/recommended/issueQualityScore.ts
+++ b/app/api/recommended/issueQualityScore.ts
@@ -1,0 +1,108 @@
+import { IssueQualityGrade, IssueQualityScore } from '../../types';
+
+/**
+ * Minimal shape required from a GitHub issue object to compute quality score.
+ * Uses optional fields so it accepts both Octokit search results and our internal Issue type.
+ */
+export interface GithubIssueLike {
+  body?: string | null;
+  comments?: number | null;
+  assignees?: ReadonlyArray<unknown> | null;
+  assignee?: unknown;
+  labels?: ReadonlyArray<{ name?: string | null } | string | null> | null;
+}
+
+const BEGINNER_LABEL_PATTERNS = [
+  'good first issue',
+  'good-first-issue',
+  'help wanted',
+  'help-wanted',
+  'beginner',
+  'beginner friendly',
+  'beginner-friendly',
+  'first-timers-only',
+  'first timers only',
+  'easy',
+];
+
+const scoreBody = (body?: string | null): number => {
+  if (!body) return 0;
+  const len = body.trim().length;
+  if (len >= 200) return 30;
+  if (len >= 100) return 20;
+  if (len >= 50) return 10;
+  return 0;
+};
+
+const scoreComments = (comments?: number | null): number => {
+  return (comments ?? 0) >= 1 ? 25 : 0;
+};
+
+const scoreAssignee = (
+  issue: GithubIssueLike,
+): { points: number; hasAssignee: boolean } => {
+  const hasAssigneesArr = Array.isArray(issue.assignees) && issue.assignees.length > 0;
+  const hasAssigneeField = issue.assignee != null && issue.assignee !== '';
+  const hasAssignee = hasAssigneesArr || hasAssigneeField;
+  return { points: hasAssignee ? 0 : 25, hasAssignee };
+};
+
+const scoreLabels = (
+  labels?: GithubIssueLike['labels'],
+): { points: number; hasBeginnerLabel: boolean } => {
+  if (!labels || labels.length === 0) {
+    return { points: 10, hasBeginnerLabel: false };
+  }
+  const names = labels
+    .map(l => {
+      if (typeof l === 'string') return l;
+      if (l && typeof l === 'object' && 'name' in l) return l.name ?? '';
+      return '';
+    })
+    .map(n => n.toLowerCase().trim())
+    .filter(n => n.length > 0);
+
+  const hasBeginnerLabel = names.some(name =>
+    BEGINNER_LABEL_PATTERNS.some(pattern => name.includes(pattern)),
+  );
+  return { points: hasBeginnerLabel ? 20 : 10, hasBeginnerLabel };
+};
+
+const gradeForScore = (score: number): IssueQualityGrade => {
+  if (score >= 80) return 'A';
+  if (score >= 50) return 'B';
+  return 'C';
+};
+
+/**
+ * Pure function: compute a 0–100 quality score and A/B/C grade for a single GitHub issue.
+ * No network calls — uses only fields already present on the issue object.
+ */
+export const calculateIssueQualityScore = (issue: GithubIssueLike): IssueQualityScore => {
+  const bodyText = issue.body ?? '';
+  const bodyLength = bodyText.trim().length;
+  const bodyPoints = scoreBody(bodyText);
+
+  const comments = issue.comments ?? 0;
+  const commentsPoints = scoreComments(comments);
+
+  const { points: assigneePoints, hasAssignee } = scoreAssignee(issue);
+  const { points: labelPoints, hasBeginnerLabel } = scoreLabels(issue.labels);
+
+  const score = bodyPoints + commentsPoints + assigneePoints + labelPoints;
+
+  return {
+    grade: gradeForScore(score),
+    score,
+    signals: {
+      bodyLength,
+      bodyPoints,
+      comments,
+      commentsPoints,
+      hasAssignee,
+      assigneePoints,
+      hasBeginnerLabel,
+      labelPoints,
+    },
+  };
+};

--- a/app/api/recommended/issueQualityScore.ts
+++ b/app/api/recommended/issueQualityScore.ts
@@ -42,7 +42,7 @@ const scoreAssignee = (
   issue: GithubIssueLike,
 ): { points: number; hasAssignee: boolean } => {
   const hasAssigneesArr = Array.isArray(issue.assignees) && issue.assignees.length > 0;
-  const hasAssigneeField = issue.assignee != null && issue.assignee !== '';
+  const hasAssigneeField = issue.assignee != null;
   const hasAssignee = hasAssigneesArr || hasAssigneeField;
   return { points: hasAssignee ? 0 : 25, hasAssignee };
 };
@@ -63,7 +63,12 @@ const scoreLabels = (
     .filter(n => n.length > 0);
 
   const hasBeginnerLabel = names.some(name =>
-    BEGINNER_LABEL_PATTERNS.some(pattern => name.includes(pattern)),
+    BEGINNER_LABEL_PATTERNS.some(pattern => {
+      if (pattern.includes(' ') || pattern.includes('-')) {
+        return name.includes(pattern);
+      }
+      return name === pattern || name.split(/[- ]/).includes(pattern);
+    }),
   );
   return { points: hasBeginnerLabel ? 20 : 10, hasBeginnerLabel };
 };

--- a/app/api/recommended/route.ts
+++ b/app/api/recommended/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from 'next/server';
 import { Issue, Label, Repository } from '../../types';
 import { calculateMaintainerScore } from './maintainerScore';
+import { calculateIssueQualityScore } from './issueQualityScore';
 import { getServerOctokit } from './serverOctokit';
 import { cacheGet, cacheSet } from '../../lib/cache';
 import { createClient } from '@/app/lib/supabase/server';
 
 const CACHE_TTL_SECONDS = 900; // 15 minutes
+const CACHE_VERSION = 'v2'; // bump when response shape changes (added qualityScore)
 
 const getFreshnessDate = (freshness: string): string => {
   const now = new Date();
@@ -81,6 +83,7 @@ export async function GET(request: Request) {
     const maxForks = isNaN(maxForksRaw) ? null : maxForksRaw;
 
     const cacheKey = JSON.stringify({
+      v: CACHE_VERSION,
       userId: sessionUserId,
       language,
       labelPreset,
@@ -187,6 +190,14 @@ export async function GET(request: Request) {
             color: l.color ?? '',
           }));
 
+        const qualityScore = calculateIssueQualityScore({
+          body: item.body,
+          comments: item.comments,
+          assignees: item.assignees,
+          assignee: item.assignee,
+          labels: item.labels,
+        });
+
         const issue: Issue = {
           id: String(item.id),
           number: item.number,
@@ -198,6 +209,9 @@ export async function GET(request: Request) {
           updatedAt: item.updated_at,
           state: item.state as 'open' | 'closed',
           repository,
+          comments: item.comments,
+          assignee: item.assignee?.login ?? null,
+          qualityScore,
         };
 
         return { issue, maintainerScore };

--- a/app/components/IssueItem.tsx
+++ b/app/components/IssueItem.tsx
@@ -1,7 +1,14 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Issue } from '../types';
 import { FaGithub, FaClock, FaStar, FaCodeBranch } from 'react-icons/fa';
-import { LuShield, LuCircleDot, LuUsers, LuFlame, LuShare2 } from 'react-icons/lu';
+import {
+  LuShield,
+  LuCircleDot,
+  LuUsers,
+  LuFlame,
+  LuShare2,
+  LuAward,
+} from 'react-icons/lu';
 import { useTranslations } from 'next-intl';
 import { useLocaleSwitch } from '@/app/providers/IntlProvider';
 import { Card } from '@/components/ui/card';
@@ -43,6 +50,12 @@ const maintainerGradeStyles = {
   A: 'bg-emerald-500/15 text-emerald-400',
   B: 'bg-amber-500/15 text-amber-400',
   C: 'bg-muted text-muted-foreground',
+};
+
+const qualityGradeStyles: Record<'A' | 'B' | 'C', string> = {
+  A: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
+  B: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
+  C: 'bg-muted text-muted-foreground border-border',
 };
 
 type CompetitionStatus = 'available' | 'inProgress' | 'hot';
@@ -132,6 +145,7 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
   const tCommon = useTranslations('common');
   const tMaintainer = useTranslations('maintainer');
   const tIssue = useTranslations('issue');
+  const tQuality = useTranslations('issue.quality');
   const { locale } = useLocaleSwitch();
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -239,6 +253,22 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
                   {tMaintainer(`grade${issue.repository.maintainerScore.grade}`)}
                 </Badge>
               )}
+              {issue.qualityScore && (
+                <Badge
+                  variant="outline"
+                  className={cn(
+                    'inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded',
+                    qualityGradeStyles[issue.qualityScore.grade],
+                  )}
+                  title={tQuality('tooltip', {
+                    grade: issue.qualityScore.grade,
+                    score: issue.qualityScore.score,
+                  })}
+                >
+                  <LuAward className="shrink-0 size-2.5" />
+                  {tQuality('label')} {issue.qualityScore.grade}
+                </Badge>
+              )}
               <CompetitionBadge
                 status={competitionStatus}
                 label={tIssue(`status.${competitionStatus}`)}
@@ -338,6 +368,23 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
                 <LuShield className="shrink-0 size-[11px]" />
                 {issue.repository.maintainerScore.grade} ·{' '}
                 {tMaintainer(`grade${issue.repository.maintainerScore.grade}`)}
+              </Badge>
+            )}
+
+            {issue.qualityScore && (
+              <Badge
+                variant="outline"
+                className={cn(
+                  'inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded',
+                  qualityGradeStyles[issue.qualityScore.grade],
+                )}
+                title={tQuality('tooltip', {
+                  grade: issue.qualityScore.grade,
+                  score: issue.qualityScore.score,
+                })}
+              >
+                <LuAward className="shrink-0 size-[11px]" />
+                {tQuality('label')} {issue.qualityScore.grade}
               </Badge>
             )}
 

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -6,6 +6,23 @@ export interface MaintainerScore {
   mergeRate: number;
 }
 
+export type IssueQualityGrade = 'A' | 'B' | 'C';
+
+export interface IssueQualityScore {
+  grade: IssueQualityGrade;
+  score: number; // 0-100
+  signals: {
+    bodyLength: number;
+    bodyPoints: number;
+    comments: number;
+    commentsPoints: number;
+    hasAssignee: boolean;
+    assigneePoints: number;
+    hasBeginnerLabel: boolean;
+    labelPoints: number;
+  };
+}
+
 export interface Repository {
   id: string;
   owner: string;
@@ -40,6 +57,7 @@ export interface Issue {
   isNew?: boolean;
   comments?: number;
   assignee?: string | null;
+  qualityScore?: IssueQualityScore;
 }
 
 // Saved (picked) issue types

--- a/messages/en.json
+++ b/messages/en.json
@@ -164,6 +164,13 @@
       "available": "Available",
       "inProgress": "In Progress",
       "hot": "Hot"
+    },
+    "quality": {
+      "label": "Quality",
+      "gradeA": "A",
+      "gradeB": "B",
+      "gradeC": "C",
+      "tooltip": "Quality {grade} · {score}/100"
     }
   },
   "maintainer": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -164,6 +164,13 @@
       "available": "참여 가능",
       "inProgress": "진행 중",
       "hot": "경쟁 중"
+    },
+    "quality": {
+      "label": "품질",
+      "gradeA": "A",
+      "gradeB": "B",
+      "gradeC": "C",
+      "tooltip": "품질 {grade}등급 · {score}/100"
     }
   },
   "maintainer": {


### PR DESCRIPTION
## Summary

- 고유 데이터 축 **P0** 기능 MVP: `good first issue` 라벨 뒤에 숨은 "진짜 기여 가능한 이슈"를 자동 판별하여 GitHub에는 없는 Pickssue 고유 신호 제공
- 4개 시그널 합산(총 100점) → A(≥80) / B(50~79) / C(<50)
  - **Body 충실도** 0~30점 (200자↑ 30 / 100~199자 20 / 50~99자 10)
  - **Comments 활성도** 0~25점 (≥1개 25 / 0개 0)
  - **Assignee 여유** 0~25점 (미배정 25)
  - **온보딩 라벨 맥락** 0~20점 (`good first issue`/`help wanted` 등 포함 20)
- 기존 `maintainerScore.ts` 패턴을 그대로 따라 구현 (순수 함수)
- `/api/recommended` 응답에 `qualityScore` 필드 추가, 캐시 키 `v2` bump
- IssueItem 카드에 `LuAward` 아이콘 배지(A=초록/B=노랑/C=회색) + tooltip
- i18n 키 `issue.quality.{label,gradeA-C,tooltip}` 추가 (en/ko)

## Priority / Scope

- 우선순위: `P0: now` (의존성 없고 기존 인프라 재사용, 즉시 고유 가치 생성)
- Scope: `scope: unique-data`

## Files changed

- `app/api/recommended/issueQualityScore.ts` (신규) — 순수 함수 `calculateIssueQualityScore`
- `app/api/recommended/route.ts` — qualityScore 주입 + 캐시 버전 bump
- `app/types/index.ts` — `IssueQualityGrade`, `IssueQualityScore` 타입 export
- `app/components/IssueItem.tsx` — 배지 표시 (compact/일반 모드)
- `messages/en.json`, `messages/ko.json` — i18n 키 추가

## Test plan

- [x] `npm run build` 성공 (TypeScript strict 통과)
- [x] `npm run lint` 통과 (pre-commit)
- [ ] 로컬에서 이슈 카드에 A/B/C 배지가 표시되는지 확인
- [ ] tooltip에 점수·시그널이 표시되는지 확인

## 남은 리스크 (Follow-up)

- 대부분의 이슈가 `good first issue`이므로 라벨 시그널의 차등화 기여가 낮음 → comments `>=5` 과열 감점, `updatedAt` 기반 신선도 보정 등 후속 개선 필요
- 실데이터에서 A/B/C 분포 편향 시 경계값 재조정

🤖 Generated with [Claude Code](https://claude.com/claude-code)