### PR TITLE
feat: 개인화 매칭 스코어 계산 모듈 추가

### DIFF
--- a/app/api/recommended/__tests__/matchScore.test.ts
+++ b/app/api/recommended/__tests__/matchScore.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateMatchScore,
+  profileFromSupabaseRow,
+  type IssueContextForMatching,
+  type UserProfileForMatching,
+} from '../matchScore';
+
+const baseIssueContext: IssueContextForMatching = {
+  repoLanguage: 'TypeScript',
+  repoTopics: ['frontend', 'testing', 'react'],
+  repoStars: 1500,
+};
+
+describe('calculateMatchScore', () => {
+  it('returns null when profile is null', () => {
+    const result = calculateMatchScore(baseIssueContext, null);
+    expect(result).toBeNull();
+  });
+
+  it('rank-1 language + 2 topic overlap + in-range scale → 40 + 25 + 20 = 85', () => {
+    const profile: UserProfileForMatching = {
+      topLanguages: [
+        { language: 'TypeScript', rank: 1 },
+        { language: 'Python', rank: 2 },
+      ],
+      starredCategories: ['frontend', 'testing', 'graphql'],
+      contributedReposAvgStars: 1000, // range [500, 5000] includes 1500
+    };
+
+    const result = calculateMatchScore(baseIssueContext, profile);
+    expect(result).not.toBeNull();
+    expect(result!.breakdown.languagePoints).toBe(40);
+    expect(result!.breakdown.topicPoints).toBe(25);
+    expect(result!.breakdown.scalePoints).toBe(20);
+    expect(result!.score).toBe(85);
+    expect(result!.reasons[0]).toContain('TypeScript');
+    expect(result!.reasons[0]).toContain('1위');
+  });
+
+  it('no language match + 0 topic overlap + out-of-range scale → score ≤ 10', () => {
+    const profile: UserProfileForMatching = {
+      topLanguages: [{ language: 'Rust', rank: 1 }],
+      starredCategories: ['embedded', 'systems'],
+      contributedReposAvgStars: 50, // range [25, 250] excludes 1500
+    };
+
+    const result = calculateMatchScore(baseIssueContext, profile);
+    expect(result).not.toBeNull();
+    expect(result!.breakdown.languagePoints).toBe(0);
+    expect(result!.breakdown.topicPoints).toBe(0);
+    expect(result!.breakdown.scalePoints).toBe(10);
+    expect(result!.score).toBeLessThanOrEqual(10);
+  });
+
+  it('contributed_repos empty → fallback range [100, 10000] gives 20pts at 1000 stars', () => {
+    const profile: UserProfileForMatching = {
+      topLanguages: null,
+      starredCategories: null,
+      contributedReposAvgStars: null,
+    };
+    const issue: IssueContextForMatching = {
+      repoLanguage: null,
+      repoTopics: [],
+      repoStars: 1000,
+    };
+
+    const result = calculateMatchScore(issue, profile);
+    expect(result).not.toBeNull();
+    expect(result!.breakdown.scalePoints).toBe(20);
+  });
+
+  it('topic overlap of 3+ caps language-side topic axis at 40', () => {
+    const profile: UserProfileForMatching = {
+      topLanguages: null,
+      starredCategories: ['frontend', 'testing', 'react', 'graphql'],
+      contributedReposAvgStars: null,
+    };
+    const issue: IssueContextForMatching = {
+      repoLanguage: null,
+      repoTopics: ['frontend', 'testing', 'react', 'extra'],
+      repoStars: 500,
+    };
+
+    const result = calculateMatchScore(issue, profile);
+    expect(result).not.toBeNull();
+    expect(result!.breakdown.topicPoints).toBe(40);
+  });
+
+  it('rank 4+ language match awards 20 points', () => {
+    const profile: UserProfileForMatching = {
+      topLanguages: [
+        { language: 'Python', rank: 1 },
+        { language: 'Go', rank: 2 },
+        { language: 'Java', rank: 3 },
+        { language: 'TypeScript', rank: 4 },
+      ],
+      starredCategories: null,
+      contributedReposAvgStars: null,
+    };
+    const result = calculateMatchScore(baseIssueContext, profile);
+    expect(result!.breakdown.languagePoints).toBe(20);
+  });
+
+  it('language matching is case-insensitive', () => {
+    const profile: UserProfileForMatching = {
+      topLanguages: [{ language: 'typescript', rank: 1 }],
+      starredCategories: null,
+      contributedReposAvgStars: null,
+    };
+    const result = calculateMatchScore(baseIssueContext, profile);
+    expect(result!.breakdown.languagePoints).toBe(40);
+  });
+});
+
+describe('profileFromSupabaseRow', () => {
+  it('returns null for null row', () => {
+    expect(profileFromSupabaseRow(null)).toBeNull();
+    expect(profileFromSupabaseRow(undefined)).toBeNull();
+  });
+
+  it('converts top_languages array order into ranks (1-indexed)', () => {
+    const row = {
+      top_languages: ['TypeScript', 'Python', 'Go'],
+      starred_categories: ['frontend', 'cli'],
+      contributed_repos: ['octocat/hello'],
+    };
+    const profile = profileFromSupabaseRow(row);
+    expect(profile).not.toBeNull();
+    expect(profile!.topLanguages).toEqual([
+      { language: 'TypeScript', rank: 1 },
+      { language: 'Python', rank: 2 },
+      { language: 'Go', rank: 3 },
+    ]);
+    expect(profile!.starredCategories).toEqual(['frontend', 'cli']);
+    expect(profile!.contributedReposAvgStars).toBeNull();
+  });
+
+  it('coerces non-array / non-string fields to null safely', () => {
+    const row = {
+      top_languages: null,
+      starred_categories: 'not-an-array',
+      contributed_repos: undefined,
+    };
+    const profile = profileFromSupabaseRow(row);
+    expect(profile).not.toBeNull();
+    expect(profile!.topLanguages).toBeNull();
+    expect(profile!.starredCategories).toBeNull();
+    expect(profile!.contributedReposAvgStars).toBeNull();
+  });
+});

--- a/app/api/recommended/matchScore.ts
+++ b/app/api/recommended/matchScore.ts
@@ -1,0 +1,198 @@
+import { MatchScore } from '../../types';
+
+/**
+ * Personalization match score (0–100) for a recommended issue.
+ *
+ * Combines three weighted axes — language fit (0–40), topic/domain overlap (0–40),
+ * and repo scale appropriateness (0–20) — using only the user_profiles fields
+ * (top_languages, starred_categories, contributed_repos) and repo metadata.
+ * Pure function: no network/DB calls.
+ *
+ * TODO: improve contributed_repos average-stars accuracy (currently the DB stores
+ * repo names only, not stars), add topic synonym handling (e.g. "react"/"reactjs"),
+ * and tune scale-bucket thresholds once user feedback is available.
+ */
+
+export interface UserProfileForMatching {
+  /** Ordered top languages (index 0 = highest rank). */
+  topLanguages: Array<{ language: string; rank: number }> | null;
+  /** Topics extracted from starred repos. */
+  starredCategories: string[] | null;
+  /** Average star count of repos the user has contributed to; null when unknown. */
+  contributedReposAvgStars: number | null;
+}
+
+export interface IssueContextForMatching {
+  repoLanguage: string | null;
+  repoTopics: string[];
+  repoStars: number;
+}
+
+/** Raw shape of a `user_profiles` row from Supabase. */
+export interface SupabaseUserProfileRow {
+  top_languages: unknown;
+  starred_categories: unknown;
+  contributed_repos: unknown;
+}
+
+const MAX_LANGUAGE_POINTS = 40;
+const MAX_TOPIC_POINTS = 40;
+const MAX_SCALE_POINTS = 20;
+
+const calculateLanguagePoints = (
+  repoLanguage: string | null,
+  topLanguages: UserProfileForMatching['topLanguages'],
+): { points: number; reason: string | null } => {
+  if (!repoLanguage || !topLanguages || topLanguages.length === 0) {
+    return { points: 0, reason: null };
+  }
+
+  const normalizedRepoLang = repoLanguage.toLowerCase();
+  const match = topLanguages.find(
+    entry => entry.language.toLowerCase() === normalizedRepoLang,
+  );
+
+  if (!match) {
+    return { points: 0, reason: null };
+  }
+
+  let points: number;
+  if (match.rank === 1) points = 40;
+  else if (match.rank <= 3) points = 30;
+  else points = 20;
+
+  return {
+    points,
+    reason: `${repoLanguage} 상위 ${match.rank}위 언어 일치`,
+  };
+};
+
+const calculateTopicPoints = (
+  repoTopics: string[],
+  starredCategories: string[] | null,
+): { points: number; reason: string | null } => {
+  if (!starredCategories || starredCategories.length === 0 || repoTopics.length === 0) {
+    return { points: 0, reason: null };
+  }
+
+  const starredSet = new Set(starredCategories.map(t => t.toLowerCase()));
+  const matched = repoTopics.filter(t => starredSet.has(t.toLowerCase()));
+  const overlap = matched.length;
+
+  if (overlap === 0) {
+    return { points: 0, reason: null };
+  }
+
+  let points: number;
+  if (overlap >= 3) points = 40;
+  else if (overlap === 2) points = 25;
+  else points = 15;
+
+  return {
+    points,
+    reason: `${matched.slice(0, 3).join(', ')} 토픽 일치(${overlap}개)`,
+  };
+};
+
+const FALLBACK_MIN_STARS = 100;
+const FALLBACK_MAX_STARS = 10000;
+const SCALE_LOWER_RATIO = 0.5;
+const SCALE_UPPER_RATIO = 5;
+
+const calculateScalePoints = (
+  repoStars: number,
+  contributedReposAvgStars: number | null,
+): { points: number; reason: string } => {
+  if (contributedReposAvgStars == null || contributedReposAvgStars <= 0) {
+    const fits = repoStars >= FALLBACK_MIN_STARS && repoStars <= FALLBACK_MAX_STARS;
+    return {
+      points: fits ? 20 : 10,
+      reason: fits ? `규모 적정(스타 ${repoStars})` : `규모 부적정(스타 ${repoStars})`,
+    };
+  }
+
+  const lower = contributedReposAvgStars * SCALE_LOWER_RATIO;
+  const upper = contributedReposAvgStars * SCALE_UPPER_RATIO;
+  const fits = repoStars >= lower && repoStars <= upper;
+  return {
+    points: fits ? 20 : 10,
+    reason: fits
+      ? `규모 적정(스타 ${repoStars}, 기여 평균 ${Math.round(contributedReposAvgStars)})`
+      : `규모 부적정(스타 ${repoStars}, 기여 평균 ${Math.round(contributedReposAvgStars)})`,
+  };
+};
+
+/**
+ * Compute a 0–100 match score for an issue against a user's profile.
+ * Returns null when the user has no profile (anonymous / not synced) so callers
+ * can hide the badge.
+ */
+export const calculateMatchScore = (
+  issueContext: IssueContextForMatching,
+  profile: UserProfileForMatching | null,
+): MatchScore | null => {
+  if (!profile) return null;
+
+  const reasons: string[] = [];
+
+  const language = calculateLanguagePoints(
+    issueContext.repoLanguage,
+    profile.topLanguages,
+  );
+  if (language.reason) reasons.push(language.reason);
+  else reasons.push('언어 데이터 없음 또는 미일치');
+
+  const topic = calculateTopicPoints(issueContext.repoTopics, profile.starredCategories);
+  if (topic.reason) reasons.push(topic.reason);
+  else reasons.push('토픽 데이터 없음 또는 미일치');
+
+  const scale = calculateScalePoints(
+    issueContext.repoStars,
+    profile.contributedReposAvgStars,
+  );
+  reasons.push(scale.reason);
+
+  const languagePoints = Math.min(language.points, MAX_LANGUAGE_POINTS);
+  const topicPoints = Math.min(topic.points, MAX_TOPIC_POINTS);
+  const scalePoints = Math.min(scale.points, MAX_SCALE_POINTS);
+  const score = languagePoints + topicPoints + scalePoints;
+
+  return {
+    score,
+    breakdown: {
+      languagePoints,
+      topicPoints,
+      scalePoints,
+    },
+    reasons,
+  };
+};
+
+const toStringArray = (value: unknown): string[] | null => {
+  if (!Array.isArray(value)) return null;
+  const arr = value.filter((v): v is string => typeof v === 'string');
+  return arr.length > 0 ? arr : null;
+};
+
+/**
+ * Convert a Supabase `user_profiles` row into the normalized matching profile.
+ * The DB stores `top_languages` as an ordered JSON string array (rank = index + 1)
+ * and `contributed_repos` as repo name strings (no stars yet) — so
+ * `contributedReposAvgStars` is set to null until that signal is enriched upstream.
+ */
+export const profileFromSupabaseRow = (
+  row: SupabaseUserProfileRow | null | undefined,
+): UserProfileForMatching | null => {
+  if (!row) return null;
+
+  const langs = toStringArray(row.top_languages);
+  const topLanguages = langs
+    ? langs.map((language, idx) => ({ language, rank: idx + 1 }))
+    : null;
+
+  return {
+    topLanguages,
+    starredCategories: toStringArray(row.starred_categories),
+    contributedReposAvgStars: null,
+  };
+};

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -6,6 +6,16 @@ export interface MaintainerScore {
   mergeRate: number;
 }
 
+export interface MatchScore {
+  score: number; // 0-100
+  breakdown: {
+    languagePoints: number;
+    topicPoints: number;
+    scalePoints: number;
+  };
+  reasons: string[];
+}
+
 export interface Repository {
   id: string;
   owner: string;
@@ -40,6 +50,7 @@ export interface Issue {
   isNew?: boolean;
   comments?: number;
   assignee?: string | null;
+  matchScore?: MatchScore;
 }
 
 // Saved (picked) issue types


### PR DESCRIPTION
## Summary

- 고유 데이터 축 **P0** 기능 MVP (2/2): 사용자 프로필 × 저장소 속성 기반 개인화 매칭 점수
- GitHub 검색은 "언어 필터"만 제공해 "내 스킬셋에 맞는 이슈" 계산 불가. Pickssue가 이미 수집 중인 `user_profiles` 데이터를 재활용해 GitHub에 없는 고유 가치 제공
- 3개 축 가중 합산 (총 100점)
  - **언어 일치** 0~40점 — `top_languages` rank 1위=40 / 2~3위=30 / 4위↓=20 / 미포함=0
  - **도메인(토픽) 일치** 0~40점 — `starred_categories` ∩ repo `topics` 교집합 크기: 3개↑=40 / 2개=25 / 1개=15 / 0개=0
  - **규모 적정성** 0~20점 — `contributed_repos` 평균 스타의 0.5×~5× 범위면 20점 (프로필 부재 시 100~10000 휴리스틱)
- 프로필 null → null 반환 (배지 숨김 가능)
- `profileFromSupabaseRow()` 헬퍼로 Supabase row → 정규화 프로필 변환

## 범위 제한 (의도적)

- **현 PR은 순수 계산 모듈 + 타입 + 단위 테스트만 포함**
- `app/api/recommended/route.ts` 통합과 UI 표시는 후속 PR에서 진행 (PR #72 머지 후 route.ts 충돌 피하기 위함)
- 후속 PR에서 필요한 작업:
  - `user_profiles` SELECT에 `starred_categories` 컬럼 추가
  - 이슈 루프에서 `octokit.repos.get` 응답의 `topics` 매핑
  - `/api/recommended` 응답에 `matchScore` 필드 주입
  - UI 정렬 옵션 "내게 맞는 순" 추가

## Priority / Scope

- 우선순위: `P0: now` (프로필 데이터 이미 수집 중, 신규 데이터 수집 불필요)
- Scope: `scope: unique-data`

## Files changed

- `app/api/recommended/matchScore.ts` (신규) — 순수 함수 + Supabase row 변환 헬퍼
- `app/api/recommended/__tests__/matchScore.test.ts` (신규) — vitest 단위 테스트 9건
- `app/types/index.ts` — `MatchScore` 타입 + `Issue.matchScore?` 필드

## Test plan

- [x] `npm test` — 52 tests passed (신규 9건 포함)
- [x] `npm run lint` 통과
- [x] `npm run build` 성공 (TypeScript strict 통과)
- [ ] 후속 PR에서 route.ts 통합 후 E2E 검증

## 남은 리스크

- 토픽 동의어 미처리 (react vs reactjs)
- `contributed_repos`가 repo name 문자열만 저장하므로 `contributedReposAvgStars`는 현재 항상 null → 폴백 분기로만 동작 (JSDoc TODO 명시)
- Cold start: 신규 사용자 토픽/언어 데이터 부족 시 점수 편차

🤖 Generated with [Claude Code](https://claude.com/claude-code)