### PR TITLE
fix: weekly-picks 빌드 그레이스풀 폴백 (CI 언블록)

### DIFF
--- a/app/lib/weeklyPicks.ts
+++ b/app/lib/weeklyPicks.ts
@@ -141,11 +141,16 @@ export async function getWeeklyPicks(): Promise<WeeklyPicksData> {
   const cached = await cacheGet<WeeklyPicksData>(weekCacheKey);
   if (cached) return cached;
 
-  let issues = await fetchIssuesFromGitHub('1w', 10);
-
-  // Fallback: if fewer than 5 issues, relax to 1 month freshness
-  if (issues.length < 5) {
-    issues = await fetchIssuesFromGitHub('1m', 10);
+  let issues: Issue[] = [];
+  try {
+    issues = await fetchIssuesFromGitHub('1w', 10);
+    if (issues.length < 5) {
+      issues = await fetchIssuesFromGitHub('1m', 10);
+    }
+  } catch (err) {
+    // Missing GitHub App env (e.g. CI build) or transient API failure —
+    // return empty data so the page still renders. ISR will repopulate later.
+    console.warn('[weeklyPicks] falling back to empty data:', err);
   }
 
   const result: WeeklyPicksData = {
@@ -155,7 +160,9 @@ export async function getWeeklyPicks(): Promise<WeeklyPicksData> {
     generatedAt: now.toISOString(),
   };
 
-  await cacheSet(weekCacheKey, result, CACHE_TTL_SECONDS);
+  if (issues.length > 0) {
+    await cacheSet(weekCacheKey, result, CACHE_TTL_SECONDS);
+  }
 
   return result;
 }


### PR DESCRIPTION
## Summary

- CI 빌드에서 `/weekly-picks` 프리렌더 시 `GITHUB_APP_*` env 누락으로 빌드 실패하던 것 수정
- `getWeeklyPicks`가 fetch 실패 시 빈 배열 반환 → 페이지는 여전히 렌더, ISR이 이후 실제 데이터로 채움
- 환경변수가 갖춰진 런타임에서는 정상 동작 유지

## Context

PR #69 Weekly Picks 병합 후 main CI 실패 상태. 이로 인해 PR #68 포함 후속 병합이 막힘.
근본 원인: 빌드 타임 prerender에 GitHub App 인증이 필요하나 CI에는 해당 env가 없음.

## Test Plan

- [x] 빌드가 env 누락 상황에서도 성공
- [ ] 프로덕션(Vercel)에서 env 있는 상태로 정상 동작 확인