### PR TITLE
feat: 활동 이벤트 로깅 테이블 추가 (#55)

### DIFF
--- a/app/lib/supabase/activityEvents.ts
+++ b/app/lib/supabase/activityEvents.ts
@@ -21,7 +21,11 @@ export async function logActivityEvent(
       event_type: eventType,
       payload,
     };
-    const { error } = await supabase.from('user_activity_events').insert(row);
+    // `as never` is required because the hand-written Database type in
+    // app/types/supabase.ts does not fully satisfy supabase-js's insert
+    // overload generics (same pattern as pickedIssues.ts). Row is still
+    // statically typed as ActivityEventInsert above.
+    const { error } = await supabase.from('user_activity_events').insert(row as never);
     if (error) {
       console.error('[activityEvents] insert failed:', error);
     }

--- a/app/lib/supabase/activityEvents.ts
+++ b/app/lib/supabase/activityEvents.ts
@@ -1,0 +1,28 @@
+import { createClient } from '@/app/lib/supabase/client';
+import { Database, Json } from '@/app/types/supabase';
+
+export type ActivityEventType =
+  | 'issue_picked'
+  | 'issue_unpicked'
+  | 'contribution_verified'
+  | 'badge_earned';
+
+type ActivityEventInsert = Database['public']['Tables']['user_activity_events']['Insert'];
+
+export async function logActivityEvent(
+  userId: string,
+  eventType: ActivityEventType,
+  payload: Json = {},
+): Promise<void> {
+  try {
+    const supabase = createClient();
+    const row: ActivityEventInsert = {
+      user_id: userId,
+      event_type: eventType,
+      payload,
+    };
+    await supabase.from('user_activity_events').insert(row as never);
+  } catch {
+    // Logging must never disrupt the main flow.
+  }
+}

--- a/app/lib/supabase/activityEvents.ts
+++ b/app/lib/supabase/activityEvents.ts
@@ -21,8 +21,12 @@ export async function logActivityEvent(
       event_type: eventType,
       payload,
     };
-    await supabase.from('user_activity_events').insert(row as never);
-  } catch {
-    // Logging must never disrupt the main flow.
+    const { error } = await supabase.from('user_activity_events').insert(row);
+    if (error) {
+      console.error('[activityEvents] insert failed:', error);
+    }
+  } catch (err) {
+    // Logging must never disrupt the main flow, but surface for debugging.
+    console.error('[activityEvents] unexpected error:', err);
   }
 }

--- a/app/lib/supabase/pickedIssues.ts
+++ b/app/lib/supabase/pickedIssues.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@/app/lib/supabase/client';
+import { logActivityEvent } from '@/app/lib/supabase/activityEvents';
 import { PickedIssue, Label } from '@/app/types';
 import { Database } from '@/app/types/supabase';
 
@@ -59,7 +60,15 @@ export async function pickIssue(userId: string, issue: PickedIssue): Promise<boo
   const { error } = await supabase
     .from('picked_issues')
     .upsert(row as never, { onConflict: 'user_id,issue_id' });
-  return !error;
+  if (error) return false;
+
+  void logActivityEvent(userId, 'issue_picked', {
+    issue_id: issue.id,
+    issue_url: issue.url,
+    repository_owner: issue.repository.owner,
+    repository_name: issue.repository.name,
+  });
+  return true;
 }
 
 export async function unpickIssue(userId: string, issueId: string): Promise<boolean> {
@@ -69,7 +78,10 @@ export async function unpickIssue(userId: string, issueId: string): Promise<bool
     .delete()
     .eq('user_id', userId)
     .eq('issue_id', issueId);
-  return !error;
+  if (error) return false;
+
+  void logActivityEvent(userId, 'issue_unpicked', { issue_id: issueId });
+  return true;
 }
 
 export async function updatePickedIssue(

--- a/app/types/supabase.ts
+++ b/app/types/supabase.ts
@@ -64,6 +64,29 @@ export interface Database {
           updated_at?: string;
         };
       };
+      user_activity_events: {
+        Row: {
+          id: string;
+          user_id: string;
+          event_type: string;
+          payload: Json;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          event_type: string;
+          payload?: Json;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          event_type?: string;
+          payload?: Json;
+          created_at?: string;
+        };
+      };
       picked_issues: {
         Row: {
           id: string;

--- a/supabase/migrations/006_create_user_activity_events.sql
+++ b/supabase/migrations/006_create_user_activity_events.sql
@@ -1,0 +1,36 @@
+-- Append-only user activity events table
+-- Powers retention/social features (Pick counts, streaks, badges, feed)
+create table user_activity_events (
+  id uuid primary key default gen_random_uuid(),
+  user_id text not null references user_profiles(id) on delete cascade,
+  event_type text not null,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+-- Indexes for common access patterns
+create index idx_user_activity_events_user_created
+  on user_activity_events(user_id, created_at desc);
+create index idx_user_activity_events_type_created
+  on user_activity_events(event_type, created_at desc);
+
+-- RLS
+alter table user_activity_events enable row level security;
+
+create policy "Users can view own activity events"
+  on user_activity_events for select
+  using (auth.uid()::text = user_id);
+
+create policy "Users can insert own activity events"
+  on user_activity_events for insert
+  with check (auth.uid()::text = user_id);
+
+-- Events are append-only; no update/delete policies.
+-- Retention (90d) handled by scheduled job; see comments below.
+
+-- Optional: pg_cron retention job (enable pg_cron extension in Supabase dashboard first)
+-- select cron.schedule(
+--   'purge_old_activity_events',
+--   '0 3 * * *',
+--   $$delete from user_activity_events where created_at < now() - interval '90 days'$$
+-- );


### PR DESCRIPTION
## Summary
- `user_activity_events` 테이블 신설 (append-only) — 후속 소셜/게이미피케이션 기능(리더보드, 스트릭, 뱃지, Pick 수, 피드)의 공통 데이터 소스
- `logActivityEvent()` 헬퍼 — 에러를 삼켜 메인 플로우를 방해하지 않는 fire-and-forget 기록
- pick/unpick 지점에 `issue_picked` / `issue_unpicked` 이벤트 자동 기록

## Schema
- `id uuid pk` / `user_id text FK user_profiles(id)` / `event_type text` / `payload jsonb` / `created_at timestamptz`
- 인덱스: `(user_id, created_at desc)`, `(event_type, created_at desc)`
- RLS: 본인 select/insert만. update/delete 정책 없음(append-only)
- 보존: 90일 TTL은 pg_cron 주석으로 제공 — 대시보드에서 `pg_cron` 확장 활성화 후 주석 해제

## Test plan
- [ ] Supabase 006 마이그레이션 적용
- [ ] 로컬에서 이슈 pick → `user_activity_events`에 `issue_picked` 행 생성 확인
- [ ] unpick → `issue_unpicked` 행 생성 확인
- [ ] 타인 user_id로 select 시 RLS 차단 확인
- [ ] `npm run lint` / `npx tsc --noEmit` 통과 (로컬 확인 완료)

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)