### PR TITLE
feat: 프라이버시 opt-in 설정 (#57)

### DIFF
--- a/app/(main)/picked/page.tsx
+++ b/app/(main)/picked/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { FaBookmark, FaSync, FaRegBookmark } from 'react-icons/fa';
 import LoginPrompt from '@/app/components/LoginPrompt';
 import PickedIssueItem from '@/app/components/PickedIssueItem';
+import PrivacyToggle from '@/app/components/PrivacyToggle';
 import { useApp } from '@/app/contexts/AppContext';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
@@ -28,6 +29,8 @@ export default function PickedPage() {
     refreshPickedIssues,
     updateNotificationFrequency,
     toggleHideClosedIssues,
+    profile,
+    updatePrivacySettings,
   } = useApp();
 
   const [refreshing, setRefreshing] = useState(false);
@@ -127,6 +130,14 @@ export default function PickedPage() {
             </Select>
           </div>
         </div>
+      )}
+
+      {/* Privacy settings */}
+      {profile !== null && (
+        <PrivacyToggle
+          isPublic={profile.is_public ?? false}
+          onToggle={updatePrivacySettings}
+        />
       )}
 
       {/* Issue list */}

--- a/app/api/profile/privacy/route.ts
+++ b/app/api/profile/privacy/route.ts
@@ -1,34 +1,43 @@
 import { createClient } from '@/app/lib/supabase/server';
+import { Database } from '@/app/types/supabase';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function PATCH(req: NextRequest) {
   try {
     const supabase = await createClient();
     const {
-      data: { session },
-    } = await supabase.auth.getSession();
+      data: { user },
+    } = await supabase.auth.getUser();
 
-    if (!session) {
+    if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const body = (await req.json()) as { is_public: boolean; public_fields?: unknown };
-    const { is_public, public_fields } = body;
+    const { is_public } = body;
 
     if (typeof is_public !== 'boolean') {
       return NextResponse.json({ error: 'is_public must be a boolean' }, { status: 400 });
     }
 
+    const updateData: Database['public']['Tables']['user_profiles']['Update'] = {
+      is_public,
+    };
+    if ('public_fields' in body) {
+      updateData.public_fields =
+        body.public_fields as Database['public']['Tables']['user_profiles']['Update']['public_fields'];
+    }
+
     const { error } = await supabase
       .from('user_profiles')
-      .update({ is_public, public_fields: public_fields ?? null } as never)
-      .eq('id', session.user.id);
+      .update(updateData)
+      .eq('id', user.id);
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
 
-    return NextResponse.json({ is_public, public_fields: public_fields ?? null });
+    return NextResponse.json({ ok: true });
   } catch (error) {
     console.error('Error updating privacy settings:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/app/api/profile/privacy/route.ts
+++ b/app/api/profile/privacy/route.ts
@@ -1,0 +1,36 @@
+import { createClient } from '@/app/lib/supabase/server';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function PATCH(req: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = (await req.json()) as { is_public: boolean; public_fields?: unknown };
+    const { is_public, public_fields } = body;
+
+    if (typeof is_public !== 'boolean') {
+      return NextResponse.json({ error: 'is_public must be a boolean' }, { status: 400 });
+    }
+
+    const { error } = await supabase
+      .from('user_profiles')
+      .update({ is_public, public_fields: public_fields ?? null } as never)
+      .eq('id', session.user.id);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ is_public, public_fields: public_fields ?? null });
+  } catch (error) {
+    console.error('Error updating privacy settings:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/profile/privacy/route.ts
+++ b/app/api/profile/privacy/route.ts
@@ -28,9 +28,12 @@ export async function PATCH(req: NextRequest) {
         body.public_fields as Database['public']['Tables']['user_profiles']['Update']['public_fields'];
     }
 
+    // `as never` is required due to hand-written Database type not fully
+    // satisfying supabase-js update overload generics. updateData is still
+    // statically typed as the Update schema above.
     const { error } = await supabase
       .from('user_profiles')
-      .update(updateData)
+      .update(updateData as never)
       .eq('id', user.id);
 
     if (error) {

--- a/app/components/PrivacyToggle.tsx
+++ b/app/components/PrivacyToggle.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Checkbox } from '@/components/ui/checkbox';
+
+interface PrivacyToggleProps {
+  isPublic: boolean;
+  onToggle: (isPublic: boolean) => Promise<void>;
+}
+
+export default function PrivacyToggle({ isPublic, onToggle }: PrivacyToggleProps) {
+  const t = useTranslations('privacy');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleChange = async (checked: boolean) => {
+    setSaving(true);
+    setError(null);
+    try {
+      await onToggle(checked);
+    } catch {
+      setError(t('saveError'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="flex items-center gap-2 text-muted-foreground cursor-pointer">
+        <Checkbox
+          checked={isPublic}
+          onCheckedChange={checked => handleChange(checked === true)}
+          disabled={saving}
+          aria-label={t('toggle.title')}
+        />
+        <span className="text-sm font-medium text-foreground">{t('toggle.title')}</span>
+        {saving && <span className="text-xs text-muted-foreground">{t('saving')}</span>}
+      </label>
+      <p className="text-xs text-muted-foreground pl-6">{t('toggle.description')}</p>
+      {error && <p className="text-xs text-destructive pl-6">{error}</p>}
+    </div>
+  );
+}

--- a/app/contexts/AppContext.tsx
+++ b/app/contexts/AppContext.tsx
@@ -50,6 +50,7 @@ interface AppContextType {
   profileLoading: boolean;
   profileError: string | null;
   syncProfile: ReturnType<typeof useUserProfile>['syncProfile'];
+  updatePrivacySettings: ReturnType<typeof useUserProfile>['updatePrivacySettings'];
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
@@ -127,9 +128,8 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   } = useRecommendedIssues();
 
   // User profile state
-  const { profile, profileLoading, profileError, syncProfile } = useUserProfile(
-    authState.isLoggedIn,
-  );
+  const { profile, profileLoading, profileError, syncProfile, updatePrivacySettings } =
+    useUserProfile(authState.isLoggedIn);
 
   // Migrate legacy localStorage keys and request notification permission on mount
   useEffect(() => {
@@ -195,6 +195,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     profileLoading,
     profileError,
     syncProfile,
+    updatePrivacySettings,
   };
 
   return <AppContext.Provider value={value}>{children}</AppContext.Provider>;

--- a/app/hooks/useUserProfile.ts
+++ b/app/hooks/useUserProfile.ts
@@ -10,6 +10,8 @@ export interface UserProfileData {
   starred_categories: string[] | null;
   contributed_repos: string[] | null;
   last_synced_at: string | null;
+  is_public?: boolean;
+  public_fields?: unknown;
 }
 
 export default function useUserProfile(isLoggedIn: boolean) {
@@ -30,6 +32,16 @@ export default function useUserProfile(isLoggedIn: boolean) {
     } finally {
       setProfileLoading(false);
     }
+  }, []);
+
+  const updatePrivacySettings = useCallback(async (isPublic: boolean): Promise<void> => {
+    const res = await fetch('/api/profile/privacy', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ is_public: isPublic }),
+    });
+    if (!res.ok) throw new Error('Failed to update privacy settings');
+    setProfile(prev => (prev ? { ...prev, is_public: isPublic } : prev));
   }, []);
 
   useEffect(() => {
@@ -56,5 +68,5 @@ export default function useUserProfile(isLoggedIn: boolean) {
       .catch(() => setProfileError('Failed to load profile'));
   }, [isLoggedIn, syncProfile]);
 
-  return { profile, profileLoading, profileError, syncProfile };
+  return { profile, profileLoading, profileError, syncProfile, updatePrivacySettings };
 }

--- a/app/types/supabase.ts
+++ b/app/types/supabase.ts
@@ -17,6 +17,8 @@ export interface Database {
           starred_categories: Json | null;
           contributed_repos: Json | null;
           last_synced_at: string | null;
+          is_public: boolean;
+          public_fields: Json | null;
         };
         Insert: {
           id: string;
@@ -25,6 +27,8 @@ export interface Database {
           starred_categories?: Json | null;
           contributed_repos?: Json | null;
           last_synced_at?: string | null;
+          is_public?: boolean;
+          public_fields?: Json | null;
         };
         Update: {
           id?: string;
@@ -33,6 +37,8 @@ export interface Database {
           starred_categories?: Json | null;
           contributed_repos?: Json | null;
           last_synced_at?: string | null;
+          is_public?: boolean;
+          public_fields?: Json | null;
         };
       };
       user_settings: {

--- a/messages/en.json
+++ b/messages/en.json
@@ -297,6 +297,14 @@
     "noIssues": "No weekly picks available yet. Check back soon!",
     "autoRefresh": "This page is automatically refreshed every week with fresh picks."
   },
+  "privacy": {
+    "toggle": {
+      "title": "Public Profile",
+      "description": "Allow others to view your profile (languages, contributions). Disabled by default (opt-in)."
+    },
+    "saving": "Saving...",
+    "saveError": "Failed to save privacy settings"
+  },
   "sync": {
     "localRepositories": "Local Repositories",
     "gistRepositories": "Cloud Repositories",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -297,6 +297,14 @@
     "noIssues": "아직 주간 추천이 없습니다. 곧 업데이트됩니다!",
     "autoRefresh": "이 페이지는 매주 자동으로 새로운 추천 이슈로 갱신됩니다."
   },
+  "privacy": {
+    "toggle": {
+      "title": "프로필 공개",
+      "description": "다른 사용자가 내 프로필(언어, 기여 이력)을 볼 수 있도록 허용합니다. 기본값은 비공개(opt-in)입니다."
+    },
+    "saving": "저장 중...",
+    "saveError": "프라이버시 설정 저장에 실패했습니다"
+  },
   "sync": {
     "localRepositories": "로컬 저장소",
     "gistRepositories": "클라우드 저장소",

--- a/supabase/migrations/007_add_privacy_to_user_profiles.sql
+++ b/supabase/migrations/007_add_privacy_to_user_profiles.sql
@@ -1,0 +1,11 @@
+-- Add privacy opt-in fields to user_profiles
+alter table user_profiles
+  add column if not exists is_public boolean not null default false,
+  add column if not exists public_fields jsonb;
+
+-- Drop existing "view own profile" policy and replace with opt-in public visibility
+drop policy if exists "Users can view own profile" on user_profiles;
+
+create policy "Users can view own or public profile"
+  on user_profiles for select
+  using (auth.uid()::text = id or is_public = true);


### PR DESCRIPTION
## Summary
- `user_profiles`에 `is_public` / `public_fields` 컬럼 추가 (기본 비공개, opt-in)
- RLS 정책 갱신: 본인 + `is_public = true`인 프로필만 타인 조회 가능
- `PATCH /api/profile/privacy` 엔드포인트로 설정 업데이트
- `PrivacyToggle` 컴포넌트를 `/picked` 상단에 통합
- i18n 키 `privacy.*` 추가 (EN/KO)

## Test plan
- [ ] `supabase/migrations/007_add_privacy_to_user_profiles.sql` 적용
- [ ] 로컬에서 토글 on/off → `user_profiles.is_public` 반영 확인
- [ ] 다른 계정으로 비공개 프로필 조회 시 RLS 차단 확인
- [ ] 공개 프로필 조회 시 정상 응답 확인
- [ ] `npm run lint` / `npx tsc --noEmit` 통과 (로컬 확인 완료)

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)