### PR TITLE
feat: 이슈 Pick 수 표시 (#59)

### DIFF
--- a/__tests__/components/pickCountBadge.test.ts
+++ b/__tests__/components/pickCountBadge.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolvePickCountDisplay,
+  PICK_COUNT_PRIVACY_THRESHOLD,
+} from '@/app/components/pickCountBadge';
+
+describe('resolvePickCountDisplay', () => {
+  describe('hidden state', () => {
+    it('hides the badge when pickCount is undefined', () => {
+      expect(resolvePickCountDisplay(undefined)).toEqual({ kind: 'hidden' });
+    });
+
+    it('hides the badge when pickCount is null', () => {
+      expect(resolvePickCountDisplay(null)).toEqual({ kind: 'hidden' });
+    });
+
+    it('hides the badge when pickCount is 0', () => {
+      expect(resolvePickCountDisplay(0)).toEqual({ kind: 'hidden' });
+    });
+
+    it('hides the badge when pickCount is negative (defensive)', () => {
+      expect(resolvePickCountDisplay(-3)).toEqual({ kind: 'hidden' });
+    });
+  });
+
+  describe('few state (privacy guard)', () => {
+    it('returns "few" for 1 pick', () => {
+      expect(resolvePickCountDisplay(1)).toEqual({ kind: 'few' });
+    });
+
+    it('returns "few" for 4 picks (just below threshold)', () => {
+      expect(resolvePickCountDisplay(4)).toEqual({ kind: 'few' });
+    });
+  });
+
+  describe('exact state', () => {
+    it('returns exact count at the threshold (5)', () => {
+      expect(resolvePickCountDisplay(PICK_COUNT_PRIVACY_THRESHOLD)).toEqual({
+        kind: 'exact',
+        count: 5,
+      });
+    });
+
+    it('returns exact count for 7 picks', () => {
+      expect(resolvePickCountDisplay(7)).toEqual({ kind: 'exact', count: 7 });
+    });
+
+    it('returns exact count for large values', () => {
+      expect(resolvePickCountDisplay(1234)).toEqual({ kind: 'exact', count: 1234 });
+    });
+  });
+
+  describe('threshold boundary', () => {
+    it('4 → few, 5 → exact (boundary behavior)', () => {
+      expect(resolvePickCountDisplay(4).kind).toBe('few');
+      expect(resolvePickCountDisplay(5).kind).toBe('exact');
+    });
+  });
+});

--- a/app/api/recommended/route.ts
+++ b/app/api/recommended/route.ts
@@ -302,16 +302,14 @@ async function fetchPickCounts(issueUrls: string[]): Promise<Map<string, number>
   try {
     const supabase = await createClient();
     const { data, error } = await supabase
-      .from('picked_issues_counts' as never)
+      .from('picked_issues_counts')
       .select('issue_url, pick_count')
-      .in('issue_url', issueUrls);
+      .in('issue_url', issueUrls)
+      .returns<Array<{ issue_url: string; pick_count: number }>>();
 
     if (error || !data) return counts;
 
-    for (const row of data as unknown as Array<{
-      issue_url: string;
-      pick_count: number;
-    }>) {
+    for (const row of data) {
       counts.set(row.issue_url, row.pick_count);
     }
   } catch {

--- a/app/api/recommended/route.ts
+++ b/app/api/recommended/route.ts
@@ -8,7 +8,7 @@ import { cacheGet, cacheSet } from '../../lib/cache';
 import { createClient } from '@/app/lib/supabase/server';
 
 const CACHE_TTL_SECONDS = 900;
-const CACHE_VERSION = 'v2';
+const CACHE_VERSION = 'v3';
 const RESULTS_PER_PAGE = 20;
 
 type Octokit = Awaited<ReturnType<typeof getServerOctokit>>;
@@ -295,6 +295,33 @@ function buildIssue(
   };
 }
 
+async function fetchPickCounts(issueUrls: string[]): Promise<Map<string, number>> {
+  const counts = new Map<string, number>();
+  if (issueUrls.length === 0) return counts;
+
+  try {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from('picked_issues_counts' as never)
+      .select('issue_url, pick_count')
+      .in('issue_url', issueUrls);
+
+    if (error || !data) return counts;
+
+    for (const row of data as unknown as Array<{
+      issue_url: string;
+      pick_count: number;
+    }>) {
+      counts.set(row.issue_url, row.pick_count);
+    }
+  } catch {
+    // If Supabase is unavailable or the view is inaccessible, silently skip —
+    // pickCount is purely additive social proof; its absence must not break recommendations.
+  }
+
+  return counts;
+}
+
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
@@ -364,6 +391,12 @@ export async function GET(request: Request) {
         i => !profile.contributedRepos.has(`${i.repository.owner}/${i.repository.name}`),
       );
     }
+
+    const pickCounts = await fetchPickCounts(issues.map(i => i.url));
+    issues = issues.map(issue => ({
+      ...issue,
+      pickCount: pickCounts.get(issue.url) ?? 0,
+    }));
 
     const result = {
       issues,

--- a/app/components/IssueItem.tsx
+++ b/app/components/IssueItem.tsx
@@ -8,6 +8,7 @@ import {
   LuFlame,
   LuShare2,
   LuAward,
+  LuBookmark,
 } from 'react-icons/lu';
 import { useTranslations } from 'next-intl';
 import { useLocaleSwitch } from '@/app/providers/IntlProvider';
@@ -15,6 +16,7 @@ import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import { formatRelativeTime } from '../utils/formatRelativeTime';
+import { resolvePickCountDisplay } from './pickCountBadge';
 
 interface IssueItemProps {
   issue: Issue;
@@ -130,8 +132,10 @@ const IssueBadges: React.FC<{ issue: Issue; compact: boolean }> = ({
   const tMaintainer = useTranslations('maintainer');
   const tIssue = useTranslations('issue');
   const tQuality = useTranslations('issue.quality');
+  const tPickCount = useTranslations('issue.pickCount');
 
   const competitionStatus = getCompetitionStatus(issue.comments, issue.assignee);
+  const pickCountDisplay = resolvePickCountDisplay(issue.pickCount);
   const padding = compact ? 'px-1.5 py-0.5' : 'px-2 py-0.5';
   const iconSize = compact ? 'size-2.5' : 'size-[11px]';
 
@@ -177,6 +181,22 @@ const IssueBadges: React.FC<{ issue: Issue; compact: boolean }> = ({
         label={tIssue(`status.${competitionStatus}`)}
         compact={compact}
       />
+
+      {pickCountDisplay.kind !== 'hidden' && (
+        <Badge
+          variant="outline"
+          className={cn(
+            'inline-flex items-center gap-1 text-xs rounded border-border bg-muted text-muted-foreground',
+            padding,
+          )}
+          title={tPickCount('tooltip')}
+        >
+          <LuBookmark className={cn('shrink-0', iconSize)} />
+          {pickCountDisplay.kind === 'few'
+            ? tPickCount('few')
+            : tPickCount('exact', { count: pickCountDisplay.count })}
+        </Badge>
+      )}
 
       {issue.matchScore != null && (
         <Badge

--- a/app/components/pickCountBadge.ts
+++ b/app/components/pickCountBadge.ts
@@ -1,0 +1,24 @@
+/**
+ * Threshold below which exact pick counts are hidden to protect user privacy
+ * in small communities where the set of pickers could otherwise be identified.
+ */
+export const PICK_COUNT_PRIVACY_THRESHOLD = 5;
+
+export type PickCountDisplay =
+  | { kind: 'hidden' }
+  | { kind: 'few' }
+  | { kind: 'exact'; count: number };
+
+/**
+ * Decide how to render the pick-count badge for an issue.
+ * - `undefined`/`0` → hidden (no one has picked yet; avoid empty social proof)
+ * - `1`..`PICK_COUNT_PRIVACY_THRESHOLD - 1` → "few" (privacy guard)
+ * - `>= PICK_COUNT_PRIVACY_THRESHOLD` → exact count
+ */
+export const resolvePickCountDisplay = (
+  pickCount: number | undefined | null,
+): PickCountDisplay => {
+  if (pickCount == null || pickCount <= 0) return { kind: 'hidden' };
+  if (pickCount < PICK_COUNT_PRIVACY_THRESHOLD) return { kind: 'few' };
+  return { kind: 'exact', count: pickCount };
+};

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -59,6 +59,7 @@ export interface Issue {
   assignee?: string | null;
   matchScore?: number; // 0-100 skill matching score (only for logged-in users with profile)
   qualityScore?: IssueQualityScore;
+  pickCount?: number; // Number of users who have picked this issue (cross-user social proof)
 }
 
 // Saved (picked) issue types

--- a/messages/en.json
+++ b/messages/en.json
@@ -176,6 +176,11 @@
       "gradeB": "B",
       "gradeC": "C",
       "tooltip": "Quality {grade} · {score}/100"
+    },
+    "pickCount": {
+      "few": "A few interested",
+      "exact": "{count} interested",
+      "tooltip": "Number of Pickssue users who saved this issue"
     }
   },
   "maintainer": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -176,6 +176,11 @@
       "gradeB": "B",
       "gradeC": "C",
       "tooltip": "품질 {grade}등급 · {score}/100"
+    },
+    "pickCount": {
+      "few": "소수 관심",
+      "exact": "{count}명 관심",
+      "tooltip": "이 이슈를 Pick한 Pickssue 사용자 수"
     }
   },
   "maintainer": {

--- a/supabase/migrations/008_grant_picked_issues_counts_to_anon.sql
+++ b/supabase/migrations/008_grant_picked_issues_counts_to_anon.sql
@@ -1,0 +1,4 @@
+-- Allow unauthenticated (anon) users to read the aggregate pick counts view.
+-- The view only exposes aggregated `count(*)` per issue_url with no user IDs,
+-- so it is safe to expose publicly for social-proof badges on the landing feed.
+grant select on picked_issues_counts to anon;


### PR DESCRIPTION
## Summary

- 추천 이슈 카드에 "N명 관심" 배지를 추가해 사회적 증거(Social Proof) + 희소성 유도
- `picked_issues_counts` 집계 뷰를 활용, `/api/recommended` 응답에 `pickCount` 필드 주입 (기존 `/api/recommended` 엔드포인트 확장 방식 — 별도 엔드포인트 추가보다 diff가 작고 클라이언트 변경 없음)
- 캐시 버전 `v2` → `v3` bump (응답 shape 변경)

## Changes

- `supabase/migrations/008_grant_picked_issues_counts_to_anon.sql` — anon 역할에도 집계 뷰 SELECT 권한 부여 (로그인 전 사용자도 카운트 확인 가능)
- `app/api/recommended/route.ts` — `fetchPickCounts()` 추가, `.in('issue_url', [...])` 배치 쿼리로 N+1 회피. 뷰 조회 실패 시 무음 처리 (추천 결과 자체는 영향 없음)
- `app/components/pickCountBadge.ts` (신규) — 순수 함수 `resolvePickCountDisplay`, 임계값 상수 `PICK_COUNT_PRIVACY_THRESHOLD = 5`
- `app/components/IssueItem.tsx` — `LuBookmark` 아이콘 neutral 배지 (compact/일반 양쪽 모드)
- `app/types/index.ts` — `Issue.pickCount?: number` 필드 추가
- `messages/en.json`, `messages/ko.json` — `issue.pickCount.{few,exact,tooltip}` i18n 키 추가
- `__tests__/components/pickCountBadge.test.ts` (신규) — 경계값 10개 테스트

## Privacy guard

- 집계 뷰는 `count(*)`만 노출하고 `user_id`/`issue_id`는 공개되지 않음
- `pick_count < 5`: `소수 관심` / `A few interested`로만 표시 (소규모 커뮤니티에서 picker 신원 추측 방지)
- `pick_count >= 5`: 정확한 수치 `N명 관심` / `N interested`
- `pick_count == 0` 또는 `undefined`: 배지 완전 숨김 (빈 social proof 역효과 방지)

## API 접근 방식

`/api/recommended` 확장을 선택함 — 이유:
1. 응답을 한 번만 받으면 되므로 클라이언트 추가 fetch 불필요
2. 기존 캐시(`v3` bump)로 pickCount까지 함께 캐시되어 뷰 조회 부하 감소
3. 신규 `/api/issues/pick-counts` 엔드포인트 추가보다 diff/인프라 부담이 작음

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 52 passed (기존 42 + 신규 10)
- [x] `npm run lint` — 0 errors (기존 extension/ 경고는 무관)
- [x] `npm run build` — 성공, `/api/recommended` 라우트 빌드 확인
- [ ] 로컬에서 테스트 계정 2개로 같은 이슈 Pick 후 30s 이내 카운트 증가 확인 (수동)
- [ ] 5명 미만/이상 분기 UI 확인 (수동)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)