### PR TITLE
feat: 활동 피드 (#66)

### DIFF
--- a/app/feed/FeedHeader.tsx
+++ b/app/feed/FeedHeader.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import React from 'react';
+import { LuActivity } from 'react-icons/lu';
+import { useTranslations } from 'next-intl';
+
+export default function FeedHeader() {
+  const t = useTranslations('feed');
+
+  return (
+    <div className="mb-8">
+      <div className="flex items-center gap-3 mb-2">
+        <LuActivity className="text-primary text-xl" />
+        <h1 className="text-2xl font-bold text-foreground">{t('title')}</h1>
+      </div>
+      <p className="text-muted-foreground text-sm">{t('subtitle')}</p>
+    </div>
+  );
+}

--- a/app/feed/FeedList.tsx
+++ b/app/feed/FeedList.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from 'next-intl';
 import { useLocaleSwitch } from '@/app/providers/IntlProvider';
 import { Card } from '@/components/ui/card';
 import { formatRelativeTime } from '@/app/utils/formatRelativeTime';
-import type { ActivityFeedItem, FeedEventType } from '@/app/lib/supabase/activityFeed';
+import type { ActivityFeedItem } from '@/app/lib/supabase/activityFeed';
 
 interface FeedListProps {
   items: ActivityFeedItem[];
@@ -46,7 +46,7 @@ function FeedRow({ item }: { item: ActivityFeedItem }) {
   const badge = badgeLabel(item.payload);
 
   let description: React.ReactNode;
-  switch (item.eventType as FeedEventType) {
+  switch (item.eventType) {
     case 'issue_picked':
       description = repo
         ? tFeed('event.issuePickedRepo', { user: item.username, repo })

--- a/app/feed/FeedList.tsx
+++ b/app/feed/FeedList.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import React from 'react';
+import Image from 'next/image';
+import { useTranslations } from 'next-intl';
+import { useLocaleSwitch } from '@/app/providers/IntlProvider';
+import { Card } from '@/components/ui/card';
+import { formatRelativeTime } from '@/app/utils/formatRelativeTime';
+import type { ActivityFeedItem, FeedEventType } from '@/app/lib/supabase/activityFeed';
+
+interface FeedListProps {
+  items: ActivityFeedItem[];
+}
+
+interface RepoLike {
+  repository_owner?: unknown;
+  repository_name?: unknown;
+}
+
+interface BadgePayload {
+  badge_id?: unknown;
+}
+
+function repoLabel(payload: Record<string, unknown>): string | null {
+  const p = payload as RepoLike;
+  if (typeof p.repository_owner === 'string' && typeof p.repository_name === 'string') {
+    return `${p.repository_owner}/${p.repository_name}`;
+  }
+  return null;
+}
+
+function badgeLabel(payload: Record<string, unknown>): string | null {
+  const p = payload as BadgePayload;
+  if (typeof p.badge_id === 'string' && p.badge_id.length > 0) {
+    return p.badge_id;
+  }
+  return null;
+}
+
+function FeedRow({ item }: { item: ActivityFeedItem }) {
+  const tCommon = useTranslations('common');
+  const tFeed = useTranslations('feed');
+  const { locale } = useLocaleSwitch();
+
+  const repo = repoLabel(item.payload);
+  const badge = badgeLabel(item.payload);
+
+  let description: React.ReactNode;
+  switch (item.eventType as FeedEventType) {
+    case 'issue_picked':
+      description = repo
+        ? tFeed('event.issuePickedRepo', { user: item.username, repo })
+        : tFeed('event.issuePicked', { user: item.username });
+      break;
+    case 'contribution_completed':
+      description = repo
+        ? tFeed('event.contributionCompletedRepo', { user: item.username, repo })
+        : tFeed('event.contributionCompleted', { user: item.username });
+      break;
+    case 'badge_earned':
+      description = badge
+        ? tFeed('event.badgeEarnedNamed', { user: item.username, badge })
+        : tFeed('event.badgeEarned', { user: item.username });
+      break;
+    default:
+      description = item.username;
+  }
+
+  return (
+    <Card className="rounded-lg border-border p-4 hover:border-primary/30 transition-colors gap-0">
+      <div className="flex items-start gap-3">
+        <div className="relative w-10 h-10 rounded-full overflow-hidden flex-shrink-0">
+          <Image
+            src={item.avatarUrl}
+            alt={`${item.username}'s avatar`}
+            width={40}
+            height={40}
+            className="rounded-full"
+            unoptimized
+          />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm text-foreground leading-relaxed">{description}</p>
+          <p className="text-xs text-muted-foreground/80 mt-1">
+            {formatRelativeTime(item.createdAt, tCommon, locale)}
+          </p>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+export default function FeedList({ items }: FeedListProps) {
+  const tFeed = useTranslations('feed');
+
+  if (items.length === 0) {
+    return (
+      <div className="text-center py-16 text-muted-foreground">
+        <p className="text-base">{tFeed('empty')}</p>
+        <p className="text-xs text-muted-foreground/60 mt-2">{tFeed('emptyHint')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {items.map(item => (
+        <FeedRow key={item.id} item={item} />
+      ))}
+    </div>
+  );
+}

--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from 'next';
+import { getPublicActivityFeed } from '@/app/lib/supabase/activityFeed';
+import FeedList from './FeedList';
+import FeedHeader from './FeedHeader';
+
+export const revalidate = 60;
+
+export const metadata: Metadata = {
+  title: 'Activity Feed',
+  description:
+    'See what the Pickssue community is working on right now — recent picks, contributions, and badges from public profiles.',
+  alternates: {
+    canonical: 'https://pickssue.dev/feed',
+  },
+  openGraph: {
+    title: 'Activity Feed | Pickssue',
+    description:
+      'See what the Pickssue community is working on right now — recent picks, contributions, and badges from public profiles.',
+    url: '/feed',
+    siteName: 'Pickssue',
+    type: 'website',
+  },
+};
+
+export default async function FeedPage() {
+  const items = await getPublicActivityFeed(50);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        <FeedHeader />
+        <FeedList items={items} />
+      </div>
+    </div>
+  );
+}

--- a/app/lib/supabase/activityFeed.ts
+++ b/app/lib/supabase/activityFeed.ts
@@ -1,0 +1,88 @@
+import { createClient as createSupabaseJsClient } from '@supabase/supabase-js';
+import { env } from '@/app/lib/env';
+import { Database, Json } from '@/app/types/supabase';
+
+export type FeedEventType = 'issue_picked' | 'contribution_completed' | 'badge_earned';
+
+export interface ActivityFeedItem {
+  id: string;
+  userId: string;
+  username: string;
+  avatarUrl: string;
+  eventType: FeedEventType;
+  payload: Record<string, unknown>;
+  createdAt: string;
+}
+
+interface PublicActivityFeedRow {
+  id: string;
+  user_id: string;
+  event_type: string;
+  payload: Json;
+  created_at: string;
+  username: string;
+}
+
+const ALLOWED_TYPES: ReadonlySet<FeedEventType> = new Set([
+  'issue_picked',
+  'contribution_completed',
+  'badge_earned',
+]);
+
+function isFeedEventType(value: string): value is FeedEventType {
+  return ALLOWED_TYPES.has(value as FeedEventType);
+}
+
+function toAvatarUrl(githubId: string): string {
+  // user_profiles.id stores the GitHub numeric ID; the static URL pattern is allowed
+  // by next.config.ts remotePatterns (avatars.githubusercontent.com/u/**).
+  return `https://avatars.githubusercontent.com/u/${githubId}?v=4`;
+}
+
+/**
+ * Fetch the most recent public activity events.
+ *
+ * Backed by the `public_activity_feed` SQL view (see migration 010), which:
+ * - joins user_profiles where is_public = true,
+ * - restricts to the last 24 hours,
+ * - applies anti-spam (max 5 events per user per hour),
+ * - filters to the three MVP event types.
+ *
+ * The default `limit` of 50 matches the spec.
+ */
+export async function getPublicActivityFeed(
+  limit: number = 50,
+): Promise<ActivityFeedItem[]> {
+  // Use a stateless anon client (no cookie binding) so the calling page can be
+  // statically generated and revalidated via `export const revalidate = 60`.
+  // The `public_activity_feed` view enforces all access control on its own.
+  const supabase = createSupabaseJsClient<Database>(
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY,
+    { auth: { persistSession: false, autoRefreshToken: false } },
+  );
+
+  const { data, error } = await supabase
+    .from('public_activity_feed')
+    .select('*')
+    .limit(limit);
+
+  if (error || !data) {
+    if (error) {
+      console.error('[activityFeed] query failed:', error);
+    }
+    return [];
+  }
+
+  return (data as unknown as PublicActivityFeedRow[])
+    .filter(row => isFeedEventType(row.event_type))
+    .map(row => ({
+      id: row.id,
+      userId: row.user_id,
+      username: row.username,
+      avatarUrl: toAvatarUrl(row.user_id),
+      eventType: row.event_type as FeedEventType,
+      payload: (row.payload as Record<string, unknown>) ?? {},
+      createdAt: row.created_at,
+    }));
+}

--- a/app/lib/supabase/activityFeed.ts
+++ b/app/lib/supabase/activityFeed.ts
@@ -1,6 +1,6 @@
 import { createClient as createSupabaseJsClient } from '@supabase/supabase-js';
 import { env } from '@/app/lib/env';
-import { Database, Json } from '@/app/types/supabase';
+import { Database } from '@/app/types/supabase';
 
 export type FeedEventType = 'issue_picked' | 'contribution_completed' | 'badge_earned';
 
@@ -12,25 +12,6 @@ export interface ActivityFeedItem {
   eventType: FeedEventType;
   payload: Record<string, unknown>;
   createdAt: string;
-}
-
-interface PublicActivityFeedRow {
-  id: string;
-  user_id: string;
-  event_type: string;
-  payload: Json;
-  created_at: string;
-  username: string;
-}
-
-const ALLOWED_TYPES: ReadonlySet<FeedEventType> = new Set([
-  'issue_picked',
-  'contribution_completed',
-  'badge_earned',
-]);
-
-function isFeedEventType(value: string): value is FeedEventType {
-  return ALLOWED_TYPES.has(value as FeedEventType);
 }
 
 function toAvatarUrl(username: string): string {
@@ -75,15 +56,16 @@ export async function getPublicActivityFeed(
     return [];
   }
 
-  return (data as unknown as PublicActivityFeedRow[])
-    .filter(row => isFeedEventType(row.event_type))
-    .map(row => ({
-      id: row.id,
-      userId: row.user_id,
-      username: row.username,
-      avatarUrl: toAvatarUrl(row.username),
-      eventType: row.event_type as FeedEventType,
-      payload: (row.payload as Record<string, unknown>) ?? {},
-      createdAt: row.created_at,
-    }));
+  // The view's WHERE clause (migration 010) already restricts event_type to
+  // the three FeedEventType values, so the cast here narrows without losing
+  // safety; no extra runtime filter needed.
+  return data.map(row => ({
+    id: row.id,
+    userId: row.user_id,
+    username: row.username,
+    avatarUrl: toAvatarUrl(row.username),
+    eventType: row.event_type as FeedEventType,
+    payload: (row.payload as Record<string, unknown>) ?? {},
+    createdAt: row.created_at,
+  }));
 }

--- a/app/lib/supabase/activityFeed.ts
+++ b/app/lib/supabase/activityFeed.ts
@@ -1,6 +1,6 @@
 import { createClient as createSupabaseJsClient } from '@supabase/supabase-js';
 import { env } from '@/app/lib/env';
-import { Database } from '@/app/types/supabase';
+import { Database, Json } from '@/app/types/supabase';
 
 export type FeedEventType = 'issue_picked' | 'contribution_completed' | 'badge_earned';
 
@@ -13,6 +13,12 @@ export interface ActivityFeedItem {
   payload: Record<string, unknown>;
   createdAt: string;
 }
+
+// The Database generic threads `Tables<>` correctly but `Views<>` resolves to
+// `never` for `.select('*')` on @supabase/supabase-js@2 (see the open
+// upstream issue), so we narrow with an explicit row shape mirrored from
+// app/types/supabase.ts.
+type PublicActivityFeedRow = Database['public']['Views']['public_activity_feed']['Row'];
 
 function toAvatarUrl(username: string): string {
   // user_profiles.id stores the Supabase auth UUID (despite the misleading
@@ -59,13 +65,13 @@ export async function getPublicActivityFeed(
   // The view's WHERE clause (migration 010) already restricts event_type to
   // the three FeedEventType values, so the cast here narrows without losing
   // safety; no extra runtime filter needed.
-  return data.map(row => ({
+  return (data as PublicActivityFeedRow[]).map(row => ({
     id: row.id,
     userId: row.user_id,
     username: row.username,
     avatarUrl: toAvatarUrl(row.username),
     eventType: row.event_type as FeedEventType,
-    payload: (row.payload as Record<string, unknown>) ?? {},
+    payload: (row.payload as Json as Record<string, unknown>) ?? {},
     createdAt: row.created_at,
   }));
 }

--- a/app/lib/supabase/activityFeed.ts
+++ b/app/lib/supabase/activityFeed.ts
@@ -33,10 +33,11 @@ function isFeedEventType(value: string): value is FeedEventType {
   return ALLOWED_TYPES.has(value as FeedEventType);
 }
 
-function toAvatarUrl(githubId: string): string {
-  // user_profiles.id stores the GitHub numeric ID; the static URL pattern is allowed
-  // by next.config.ts remotePatterns (avatars.githubusercontent.com/u/**).
-  return `https://avatars.githubusercontent.com/u/${githubId}?v=4`;
+function toAvatarUrl(username: string): string {
+  // user_profiles.id stores the Supabase auth UUID (despite the misleading
+  // -- github_id comment in migration 001), so we resolve avatars by username
+  // via github.com's redirect endpoint. next.config.ts must allow this host.
+  return `https://github.com/${encodeURIComponent(username)}.png?size=80`;
 }
 
 /**
@@ -80,7 +81,7 @@ export async function getPublicActivityFeed(
       id: row.id,
       userId: row.user_id,
       username: row.username,
-      avatarUrl: toAvatarUrl(row.user_id),
+      avatarUrl: toAvatarUrl(row.username),
       eventType: row.event_type as FeedEventType,
       payload: (row.payload as Record<string, unknown>) ?? {},
       createdAt: row.created_at,

--- a/app/types/supabase.ts
+++ b/app/types/supabase.ts
@@ -166,6 +166,16 @@ export interface Database {
           pick_count: number;
         };
       };
+      public_activity_feed: {
+        Row: {
+          id: string;
+          user_id: string;
+          event_type: string;
+          payload: Json;
+          created_at: string;
+          username: string;
+        };
+      };
     };
     Functions: Record<string, never>;
     Enums: Record<string, never>;

--- a/messages/en.json
+++ b/messages/en.json
@@ -345,6 +345,20 @@
     "refreshNote": "These picks are personalized for today. Come back tomorrow for a new set.",
     "empty": "No discoveries available today. Check back tomorrow!"
   },
+  "feed": {
+    "title": "Activity Feed",
+    "subtitle": "What the Pickssue community is doing right now",
+    "empty": "No activity yet",
+    "emptyHint": "Public activity from the last 24 hours will show up here.",
+    "event": {
+      "issuePicked": "{user} picked a new issue",
+      "issuePickedRepo": "{user} picked an issue in {repo}",
+      "contributionCompleted": "{user} completed a contribution",
+      "contributionCompletedRepo": "{user} completed a contribution to {repo}",
+      "badgeEarned": "{user} earned a new badge",
+      "badgeEarnedNamed": "{user} earned the {badge} badge"
+    }
+  },
   "sync": {
     "localRepositories": "Local Repositories",
     "gistRepositories": "Cloud Repositories",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -345,6 +345,20 @@
     "refreshNote": "오늘 하루 동안 동일한 이슈가 표시됩니다. 내일 다시 방문하면 새로운 이슈를 만나보세요.",
     "empty": "오늘 추천할 이슈가 없습니다. 내일 다시 확인해보세요!"
   },
+  "feed": {
+    "title": "활동 피드",
+    "subtitle": "Pickssue 커뮤니티에서 지금 일어나는 일",
+    "empty": "아직 활동이 없어요",
+    "emptyHint": "최근 24시간 동안의 공개 활동이 여기에 표시됩니다.",
+    "event": {
+      "issuePicked": "{user}님이 새 이슈를 Pick 했어요",
+      "issuePickedRepo": "{user}님이 {repo}의 이슈를 Pick 했어요",
+      "contributionCompleted": "{user}님이 기여를 완료했어요",
+      "contributionCompletedRepo": "{user}님이 {repo}에 기여를 완료했어요",
+      "badgeEarned": "{user}님이 새 뱃지를 획득했어요",
+      "badgeEarnedNamed": "{user}님이 '{badge}' 뱃지를 획득했어요"
+    }
+  },
   "sync": {
     "localRepositories": "로컬 저장소",
     "gistRepositories": "클라우드 저장소",

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,11 @@ const nextConfig: NextConfig = {
         hostname: 'avatars.githubusercontent.com',
         pathname: '/u/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'github.com',
+        pathname: '/*.png',
+      },
     ],
   },
   // Performance optimizations

--- a/supabase/migrations/010_create_public_activity_feed.sql
+++ b/supabase/migrations/010_create_public_activity_feed.sql
@@ -1,0 +1,43 @@
+-- Public activity feed for /feed route (#66)
+-- Exposes user_activity_events of users who opted in via user_profiles.is_public,
+-- limited to the last 24 hours and rate-limited to 5 events per user per hour
+-- (anti-spam) via row_number() window function.
+--
+-- The view runs with the privileges of the view owner (Supabase `postgres`),
+-- so it bypasses the per-row RLS on user_activity_events. The is_public join
+-- is therefore the *only* gate — make sure that condition stays correct.
+
+create or replace view public_activity_feed as
+with ranked as (
+  select
+    e.id,
+    e.user_id,
+    e.event_type,
+    e.payload,
+    e.created_at,
+    p.username,
+    row_number() over (
+      partition by e.user_id, date_trunc('hour', e.created_at)
+      order by e.created_at desc
+    ) as rn_in_hour
+  from user_activity_events e
+  inner join user_profiles p
+    on p.id = e.user_id
+  where p.is_public = true
+    and e.created_at >= now() - interval '24 hours'
+    and e.event_type in ('issue_picked', 'contribution_completed', 'badge_earned')
+)
+select
+  id,
+  user_id,
+  event_type,
+  payload,
+  created_at,
+  username
+from ranked
+where rn_in_hour <= 5
+order by created_at desc;
+
+-- Allow both authenticated and anonymous (logged-out) visitors to read the feed.
+-- The view itself filters on is_public, so private users are never exposed.
+grant select on public_activity_feed to anon, authenticated;


### PR DESCRIPTION
## Summary

- 공개 프로필(`is_public=true`) 사용자들의 최근 활동을 SSR `/feed` 라우트에서 보여주는 활동 피드 추가 (Wave 2A #66)
- 도배 방지: 사용자당 시간당 최대 5건 (`row_number()` window function)
- 이벤트 타입 우선 3개: `issue_picked`, `contribution_completed`, `badge_earned`
- ISR `revalidate = 60s` (빌드 결과: `○ /feed 1m 1y`)

## Schema (migration 010)

`supabase/migrations/010_create_public_activity_feed.sql` — `public_activity_feed` SQL view 생성:

- `user_activity_events` ⨝ `user_profiles` ON `is_public = true`
- 최근 24h, MVP 이벤트 3종만 포함
- `row_number() OVER (PARTITION BY user_id, date_trunc('hour', created_at) ORDER BY created_at DESC) <= 5` 적용
- `grant select ... to anon, authenticated` (피드는 로그아웃 상태에서도 조회 가능, view 자체에서 is_public 게이팅)

## Changes

- `app/feed/page.tsx` — SSR 페이지, `revalidate = 60`, 메타데이터 + canonical
- `app/feed/FeedHeader.tsx` — i18n 헤더(client island)
- `app/feed/FeedList.tsx` — 아바타 + 한 줄 설명 + 상대 시간 + 빈 상태 (client)
- `app/lib/supabase/activityFeed.ts` — `public_activity_feed` view 쿼리, ISR 호환을 위해 cookie-free anon 클라이언트 사용
- `app/types/supabase.ts` — `public_activity_feed` view 타입 추가
- `messages/{en,ko}.json` — `feed.*` 키 추가 (`title`, `subtitle`, `empty`, `emptyHint`, 6개 `event.*` 메시지)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` 0 errors (extension/ 23 warnings는 기존 이슈)
- [x] `npm run build` success — `/feed`가 `○` (Static, ISR `1m`)으로 prerender됨
- [ ] migration 010 적용 후 (`npx supabase db push`) 실제 데이터로 smoke test
- [ ] 비공개 프로필(`is_public=false`) 사용자의 활동 이벤트가 노출되지 않는지 확인
- [ ] 같은 사용자가 한 시간 안에 6번째 이벤트 발행 시 5건만 보이는지 확인
- [ ] 빈 상태 ("아직 활동이 없어요" / "No activity yet") 표시 확인

## Follow-up

- 빌드 시 `Could not find the table 'public.public_activity_feed'` 런타임 에러는 정상 — 머지 후 `npx supabase db push`로 migration 010 적용 필요 (wave-2.md §6 정책)
- `badge_earned` 이벤트는 #61 머지 후에야 데이터가 채워짐 (스코프 외)
- 페이지네이션, 무한 스크롤, 실시간 구독, 필터링 UI는 명시적으로 out of scope
- 공개 프로필 페이지 클릭은 #62 후속

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)