### PR TITLE
feat: 이슈별 기여 팁 UGC (#45)

### DIFF
--- a/app/api/tips/like/route.ts
+++ b/app/api/tips/like/route.ts
@@ -48,6 +48,11 @@ export async function POST(req: NextRequest) {
       .from('issue_tip_likes')
       .insert(insertRow as never);
     if (insErr) {
+      // 23505 = unique_violation. The select-then-insert toggle is racy; if a
+      // concurrent request already inserted the row, treat as success.
+      if ((insErr as { code?: string }).code === '23505') {
+        return NextResponse.json({ liked: true });
+      }
       return NextResponse.json({ error: insErr.message }, { status: 500 });
     }
     return NextResponse.json({ liked: true });

--- a/app/api/tips/like/route.ts
+++ b/app/api/tips/like/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/app/lib/supabase/server';
+import type { Database } from '@/app/types/supabase';
+
+export async function POST(req: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = (await req.json().catch(() => null)) as { tipId?: unknown } | null;
+    const tipId = typeof body?.tipId === 'string' ? body.tipId : '';
+    if (!tipId) {
+      return NextResponse.json({ error: 'tipId is required' }, { status: 400 });
+    }
+
+    // Toggle: try delete first, if no row was affected, insert.
+    const { data: existing } = await supabase
+      .from('issue_tip_likes')
+      .select('tip_id')
+      .eq('tip_id', tipId)
+      .eq('user_id', user.id)
+      .maybeSingle<{ tip_id: string }>();
+
+    if (existing) {
+      const { error: delErr } = await supabase
+        .from('issue_tip_likes')
+        .delete()
+        .eq('tip_id', tipId)
+        .eq('user_id', user.id);
+      if (delErr) {
+        return NextResponse.json({ error: delErr.message }, { status: 500 });
+      }
+      return NextResponse.json({ liked: false });
+    }
+
+    const insertRow: Database['public']['Tables']['issue_tip_likes']['Insert'] = {
+      tip_id: tipId,
+      user_id: user.id,
+    };
+
+    const { error: insErr } = await supabase
+      .from('issue_tip_likes')
+      .insert(insertRow as never);
+    if (insErr) {
+      return NextResponse.json({ error: insErr.message }, { status: 500 });
+    }
+    return NextResponse.json({ liked: true });
+  } catch (error) {
+    console.error('Error toggling tip like:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/tips/report/route.ts
+++ b/app/api/tips/report/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/app/lib/supabase/server';
+import type { Database } from '@/app/types/supabase';
+
+const MAX_REASON_LENGTH = 280;
+
+export async function POST(req: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = (await req.json().catch(() => null)) as {
+      tipId?: unknown;
+      reason?: unknown;
+    } | null;
+
+    const tipId = typeof body?.tipId === 'string' ? body.tipId : '';
+    const reasonRaw = typeof body?.reason === 'string' ? body.reason.trim() : '';
+    const reason = reasonRaw.slice(0, MAX_REASON_LENGTH) || null;
+
+    if (!tipId) {
+      return NextResponse.json({ error: 'tipId is required' }, { status: 400 });
+    }
+
+    const insertRow: Database['public']['Tables']['issue_tip_reports']['Insert'] = {
+      tip_id: tipId,
+      user_id: user.id,
+      reason,
+    };
+
+    const { error } = await supabase.from('issue_tip_reports').insert(insertRow as never);
+
+    if (error) {
+      // Duplicate report (PK conflict) — surface as 409 so client can show "already reported"
+      if (error.code === '23505') {
+        return NextResponse.json({ error: 'already reported' }, { status: 409 });
+      }
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('Error filing tip report:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/tips/route.ts
+++ b/app/api/tips/route.ts
@@ -1,0 +1,192 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/app/lib/supabase/server';
+import type { Database } from '@/app/types/supabase';
+
+const MAX_CONTENT_LENGTH = 280;
+
+type TipRow = Database['public']['Tables']['issue_tips']['Row'];
+
+export async function GET(req: NextRequest) {
+  try {
+    const issueUrl = req.nextUrl.searchParams.get('issueUrl');
+    if (!issueUrl) {
+      return NextResponse.json({ error: 'issueUrl is required' }, { status: 400 });
+    }
+
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    const { data, error } = await supabase
+      .from('issue_tips')
+      .select('id, issue_url, user_id, content, like_count, created_at')
+      .eq('issue_url', issueUrl)
+      .is('hidden_at', null)
+      .order('like_count', { ascending: false })
+      .order('created_at', { ascending: false })
+      .returns<
+        Array<
+          Pick<
+            TipRow,
+            'id' | 'issue_url' | 'user_id' | 'content' | 'like_count' | 'created_at'
+          >
+        >
+      >();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    const tips = data ?? [];
+    const tipIds = tips.map(t => t.id);
+
+    // Likes/reports the current user has made (used to render toggle state)
+    let likedSet = new Set<string>();
+    let reportedSet = new Set<string>();
+    if (user && tipIds.length > 0) {
+      const [{ data: likes }, { data: reports }] = await Promise.all([
+        supabase
+          .from('issue_tip_likes')
+          .select('tip_id')
+          .eq('user_id', user.id)
+          .in('tip_id', tipIds)
+          .returns<Array<{ tip_id: string }>>(),
+        supabase
+          .from('issue_tip_reports')
+          .select('tip_id')
+          .eq('user_id', user.id)
+          .in('tip_id', tipIds)
+          .returns<Array<{ tip_id: string }>>(),
+      ]);
+      likedSet = new Set((likes ?? []).map(r => r.tip_id));
+      reportedSet = new Set((reports ?? []).map(r => r.tip_id));
+    }
+
+    const enriched = tips.map(t => ({
+      id: t.id,
+      issueUrl: t.issue_url,
+      userId: t.user_id,
+      content: t.content,
+      likeCount: t.like_count,
+      createdAt: t.created_at,
+      isOwn: user ? t.user_id === user.id : false,
+      isLiked: likedSet.has(t.id),
+      isReported: reportedSet.has(t.id),
+    }));
+
+    return NextResponse.json({ tips: enriched, total: enriched.length });
+  } catch (error) {
+    console.error('Error fetching tips:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = (await req.json().catch(() => null)) as {
+      issueUrl?: unknown;
+      content?: unknown;
+    } | null;
+
+    const issueUrl = typeof body?.issueUrl === 'string' ? body.issueUrl.trim() : '';
+    const content = typeof body?.content === 'string' ? body.content.trim() : '';
+
+    if (!issueUrl) {
+      return NextResponse.json({ error: 'issueUrl is required' }, { status: 400 });
+    }
+    if (!content) {
+      return NextResponse.json({ error: 'content is required' }, { status: 400 });
+    }
+    if (content.length > MAX_CONTENT_LENGTH) {
+      return NextResponse.json(
+        { error: `content must be ${MAX_CONTENT_LENGTH} characters or fewer` },
+        { status: 400 },
+      );
+    }
+
+    const insertRow: Database['public']['Tables']['issue_tips']['Insert'] = {
+      issue_url: issueUrl,
+      user_id: user.id,
+      content,
+    };
+
+    const { data, error } = await supabase
+      .from('issue_tips')
+      .insert(insertRow as never)
+      .select('id, issue_url, user_id, content, like_count, created_at')
+      .single<
+        Pick<
+          TipRow,
+          'id' | 'issue_url' | 'user_id' | 'content' | 'like_count' | 'created_at'
+        >
+      >();
+
+    if (error || !data) {
+      return NextResponse.json(
+        { error: error?.message ?? 'Failed to create tip' },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({
+      tip: {
+        id: data.id,
+        issueUrl: data.issue_url,
+        userId: data.user_id,
+        content: data.content,
+        likeCount: data.like_count,
+        createdAt: data.created_at,
+        isOwn: true,
+        isLiked: false,
+        isReported: false,
+      },
+    });
+  } catch (error) {
+    console.error('Error creating tip:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  try {
+    const id = req.nextUrl.searchParams.get('id');
+    if (!id) {
+      return NextResponse.json({ error: 'id is required' }, { status: 400 });
+    }
+
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // RLS enforces ownership; the eq filter is belt-and-suspenders.
+    const { error } = await supabase
+      .from('issue_tips')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', user.id);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('Error deleting tip:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/tips/route.ts
+++ b/app/api/tips/route.ts
@@ -4,13 +4,24 @@ import type { Database } from '@/app/types/supabase';
 
 const MAX_CONTENT_LENGTH = 280;
 
+// Constrain `issue_url` to canonical GitHub issue/PR form so the table can't be
+// used as arbitrary key/value storage (e.g. `https://example.com/#xss`).
+const ISSUE_URL_RE = /^https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/(?:issues|pull)\/\d+$/;
+
+function isValidIssueUrl(url: string): boolean {
+  return ISSUE_URL_RE.test(url);
+}
+
 type TipRow = Database['public']['Tables']['issue_tips']['Row'];
 
 export async function GET(req: NextRequest) {
   try {
     const issueUrl = req.nextUrl.searchParams.get('issueUrl');
-    if (!issueUrl) {
-      return NextResponse.json({ error: 'issueUrl is required' }, { status: 400 });
+    if (!issueUrl || !isValidIssueUrl(issueUrl)) {
+      return NextResponse.json(
+        { error: 'Valid GitHub issue or PR URL is required' },
+        { status: 400 },
+      );
     }
 
     const supabase = await createClient();
@@ -101,8 +112,11 @@ export async function POST(req: NextRequest) {
     const issueUrl = typeof body?.issueUrl === 'string' ? body.issueUrl.trim() : '';
     const content = typeof body?.content === 'string' ? body.content.trim() : '';
 
-    if (!issueUrl) {
-      return NextResponse.json({ error: 'issueUrl is required' }, { status: 400 });
+    if (!issueUrl || !isValidIssueUrl(issueUrl)) {
+      return NextResponse.json(
+        { error: 'Valid GitHub issue or PR URL is required' },
+        { status: 400 },
+      );
     }
     if (!content) {
       return NextResponse.json({ error: 'content is required' }, { status: 400 });

--- a/app/components/IssueItem.tsx
+++ b/app/components/IssueItem.tsx
@@ -17,6 +17,7 @@ import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import { formatRelativeTime } from '../utils/formatRelativeTime';
 import { resolvePickCountDisplay } from './pickCountBadge';
+import IssueTips from './IssueTips';
 
 interface IssueItemProps {
   issue: Issue;
@@ -477,6 +478,8 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
               />
             </div>
           </div>
+
+          <IssueTips issueUrl={issue.url} />
         </div>
       </div>
     </Card>

--- a/app/components/IssueTips.tsx
+++ b/app/components/IssueTips.tsx
@@ -1,0 +1,323 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { LuLightbulb, LuHeart, LuFlag, LuTrash2, LuLoader } from 'react-icons/lu';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/app/contexts/AppContext';
+import { useLocaleSwitch } from '@/app/providers/IntlProvider';
+import { formatRelativeTime } from '../utils/formatRelativeTime';
+import { cn } from '@/lib/utils';
+
+interface IssueTipsProps {
+  issueUrl: string;
+}
+
+interface Tip {
+  id: string;
+  issueUrl: string;
+  userId: string;
+  content: string;
+  likeCount: number;
+  createdAt: string;
+  isOwn: boolean;
+  isLiked: boolean;
+  isReported: boolean;
+}
+
+const MAX_CONTENT_LENGTH = 280;
+
+const IssueTips: React.FC<IssueTipsProps> = ({ issueUrl }) => {
+  const t = useTranslations('tips');
+  const tCommon = useTranslations('common');
+  const { authState } = useAuth();
+  const { locale } = useLocaleSwitch();
+
+  const [open, setOpen] = useState(false);
+  const [tips, setTips] = useState<Tip[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [hasFetched, setHasFetched] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const fetchedUrlRef = useRef<string | null>(null);
+
+  const fetchTips = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/tips?issueUrl=${encodeURIComponent(issueUrl)}`);
+      if (!res.ok) {
+        setTips([]);
+        return;
+      }
+      const json = (await res.json()) as { tips?: Tip[] };
+      setTips(json.tips ?? []);
+    } catch {
+      setTips([]);
+    } finally {
+      setLoading(false);
+      setHasFetched(true);
+    }
+  }, [issueUrl]);
+
+  // Fetch on first expand
+  useEffect(() => {
+    if (open && fetchedUrlRef.current !== issueUrl) {
+      fetchedUrlRef.current = issueUrl;
+      void fetchTips();
+    }
+  }, [open, issueUrl, fetchTips]);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      const content = draft.trim();
+      if (!content || content.length > MAX_CONTENT_LENGTH || submitting) return;
+      setSubmitting(true);
+      try {
+        const res = await fetch('/api/tips', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ issueUrl, content }),
+        });
+        if (!res.ok) return;
+        const json = (await res.json()) as { tip?: Tip };
+        if (json.tip) {
+          setTips(prev => [json.tip!, ...prev]);
+          setDraft('');
+        }
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [draft, submitting, issueUrl],
+  );
+
+  const handleLike = useCallback(
+    async (tip: Tip) => {
+      if (!authState.isLoggedIn) return;
+      // Optimistic update
+      setTips(prev =>
+        prev.map(p =>
+          p.id === tip.id
+            ? {
+                ...p,
+                isLiked: !p.isLiked,
+                likeCount: Math.max(0, p.likeCount + (p.isLiked ? -1 : 1)),
+              }
+            : p,
+        ),
+      );
+      try {
+        const res = await fetch('/api/tips/like', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tipId: tip.id }),
+        });
+        if (!res.ok) {
+          // Roll back
+          setTips(prev =>
+            prev.map(p =>
+              p.id === tip.id
+                ? {
+                    ...p,
+                    isLiked: tip.isLiked,
+                    likeCount: tip.likeCount,
+                  }
+                : p,
+            ),
+          );
+        }
+      } catch {
+        setTips(prev =>
+          prev.map(p =>
+            p.id === tip.id
+              ? { ...p, isLiked: tip.isLiked, likeCount: tip.likeCount }
+              : p,
+          ),
+        );
+      }
+    },
+    [authState.isLoggedIn],
+  );
+
+  const handleReport = useCallback(
+    async (tip: Tip) => {
+      if (!authState.isLoggedIn || tip.isReported) return;
+      setTips(prev => prev.map(p => (p.id === tip.id ? { ...p, isReported: true } : p)));
+      try {
+        const res = await fetch('/api/tips/report', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tipId: tip.id }),
+        });
+        if (!res.ok && res.status !== 409) {
+          // Roll back on hard failure (treat 409 = already reported as success)
+          setTips(prev =>
+            prev.map(p => (p.id === tip.id ? { ...p, isReported: false } : p)),
+          );
+        }
+      } catch {
+        setTips(prev =>
+          prev.map(p => (p.id === tip.id ? { ...p, isReported: false } : p)),
+        );
+      }
+    },
+    [authState.isLoggedIn],
+  );
+
+  const handleDelete = useCallback(
+    async (tip: Tip) => {
+      if (typeof window !== 'undefined' && !window.confirm(t('deleteConfirm'))) return;
+      const previous = tips;
+      setTips(prev => prev.filter(p => p.id !== tip.id));
+      try {
+        const res = await fetch(`/api/tips?id=${encodeURIComponent(tip.id)}`, {
+          method: 'DELETE',
+        });
+        if (!res.ok) setTips(previous);
+      } catch {
+        setTips(previous);
+      }
+    },
+    [tips, t],
+  );
+
+  const remaining = MAX_CONTENT_LENGTH - draft.length;
+  const isOverLimit = draft.length > MAX_CONTENT_LENGTH;
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="mt-3">
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          onClick={e => e.stopPropagation()}
+        >
+          <LuLightbulb className="size-3.5" />
+          <span>
+            {hasFetched
+              ? tips.length === 0
+                ? t('add')
+                : t('countLabel', { count: tips.length })
+              : t('toggle')}
+          </span>
+        </button>
+      </CollapsibleTrigger>
+
+      <CollapsibleContent className="mt-2 space-y-3">
+        {authState.isLoggedIn ? (
+          <form onSubmit={handleSubmit} className="space-y-1.5">
+            <textarea
+              value={draft}
+              onChange={e => setDraft(e.target.value)}
+              placeholder={t('placeholder')}
+              maxLength={MAX_CONTENT_LENGTH + 50}
+              rows={2}
+              className={cn(
+                'w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm',
+                'placeholder:text-muted-foreground resize-y outline-none',
+                'focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50',
+                isOverLimit && 'border-destructive',
+              )}
+              aria-label={t('placeholder')}
+            />
+            <div className="flex items-center justify-between text-xs">
+              <span
+                className={cn('text-muted-foreground', isOverLimit && 'text-destructive')}
+              >
+                {t('charCount', { count: draft.length, max: MAX_CONTENT_LENGTH })}
+              </span>
+              <Button
+                type="submit"
+                size="xs"
+                disabled={submitting || !draft.trim() || isOverLimit || remaining < 0}
+              >
+                {submitting && <LuLoader className="animate-spin" />}
+                {t('submit')}
+              </Button>
+            </div>
+          </form>
+        ) : (
+          <p className="text-xs text-muted-foreground">{t('loginRequired')}</p>
+        )}
+
+        {loading && (
+          <p className="text-xs text-muted-foreground inline-flex items-center gap-1">
+            <LuLoader className="size-3 animate-spin" /> {tCommon('loading')}
+          </p>
+        )}
+
+        {!loading && hasFetched && tips.length === 0 && (
+          <p className="text-xs text-muted-foreground">{t('empty')}</p>
+        )}
+
+        {!loading && tips.length > 0 && (
+          <ul className="space-y-2">
+            {tips.map(tip => (
+              <li
+                key={tip.id}
+                className="rounded-md border border-border bg-muted/40 p-2.5 text-sm"
+              >
+                <p className="whitespace-pre-wrap break-words text-foreground">
+                  {tip.content}
+                </p>
+                <div className="mt-1.5 flex items-center gap-3 text-xs text-muted-foreground">
+                  <span>{formatRelativeTime(tip.createdAt, tCommon, locale)}</span>
+                  <button
+                    type="button"
+                    onClick={() => handleLike(tip)}
+                    disabled={!authState.isLoggedIn}
+                    aria-label={t('like')}
+                    className={cn(
+                      'inline-flex items-center gap-1 transition-colors',
+                      authState.isLoggedIn
+                        ? 'hover:text-foreground'
+                        : 'cursor-not-allowed opacity-60',
+                      tip.isLiked && 'text-rose-500 hover:text-rose-500/80',
+                    )}
+                  >
+                    <LuHeart className={cn('size-3.5', tip.isLiked && 'fill-current')} />
+                    <span>{tip.likeCount}</span>
+                  </button>
+                  {tip.isOwn ? (
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(tip)}
+                      aria-label={tCommon('cancel')}
+                      className="inline-flex items-center gap-1 hover:text-destructive transition-colors ml-auto"
+                    >
+                      <LuTrash2 className="size-3.5" />
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => handleReport(tip)}
+                      disabled={!authState.isLoggedIn || tip.isReported}
+                      aria-label={t('report')}
+                      className={cn(
+                        'inline-flex items-center gap-1 transition-colors ml-auto',
+                        authState.isLoggedIn && !tip.isReported
+                          ? 'hover:text-foreground'
+                          : 'cursor-not-allowed opacity-60',
+                      )}
+                    >
+                      <LuFlag className="size-3.5" />
+                      <span>{tip.isReported ? t('reported') : t('report')}</span>
+                    </button>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};
+
+export default IssueTips;

--- a/app/components/IssueTips.tsx
+++ b/app/components/IssueTips.tsx
@@ -44,6 +44,7 @@ const IssueTips: React.FC<IssueTipsProps> = ({ issueUrl }) => {
   const [hasFetched, setHasFetched] = useState(false);
   const [draft, setDraft] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const fetchedUrlRef = useRef<string | null>(null);
 
   const fetchTips = useCallback(async () => {
@@ -78,23 +79,30 @@ const IssueTips: React.FC<IssueTipsProps> = ({ issueUrl }) => {
       const content = draft.trim();
       if (!content || content.length > MAX_CONTENT_LENGTH || submitting) return;
       setSubmitting(true);
+      setSubmitError(null);
       try {
         const res = await fetch('/api/tips', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ issueUrl, content }),
         });
-        if (!res.ok) return;
+        if (!res.ok) {
+          const err = (await res.json().catch(() => null)) as { error?: string } | null;
+          setSubmitError(err?.error ?? t('submitError'));
+          return;
+        }
         const json = (await res.json()) as { tip?: Tip };
         if (json.tip) {
           setTips(prev => [json.tip!, ...prev]);
           setDraft('');
         }
+      } catch {
+        setSubmitError(t('submitError'));
       } finally {
         setSubmitting(false);
       }
     },
-    [draft, submitting, issueUrl],
+    [draft, submitting, issueUrl, t],
   );
 
   const handleLike = useCallback(
@@ -241,6 +249,11 @@ const IssueTips: React.FC<IssueTipsProps> = ({ issueUrl }) => {
                 {t('submit')}
               </Button>
             </div>
+            {submitError && (
+              <p className="text-xs text-destructive" role="alert">
+                {submitError}
+              </p>
+            )}
           </form>
         ) : (
           <p className="text-xs text-muted-foreground">{t('loginRequired')}</p>

--- a/app/types/supabase.ts
+++ b/app/types/supabase.ts
@@ -155,6 +155,75 @@ export interface Database {
           closing_pr_author?: string | null;
         };
       };
+      issue_tips: {
+        Row: {
+          id: string;
+          issue_url: string;
+          user_id: string;
+          content: string;
+          like_count: number;
+          report_count: number;
+          hidden_at: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          issue_url: string;
+          user_id: string;
+          content: string;
+          like_count?: number;
+          report_count?: number;
+          hidden_at?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          issue_url?: string;
+          user_id?: string;
+          content?: string;
+          like_count?: number;
+          report_count?: number;
+          hidden_at?: string | null;
+          created_at?: string;
+        };
+      };
+      issue_tip_likes: {
+        Row: {
+          tip_id: string;
+          user_id: string;
+          created_at: string;
+        };
+        Insert: {
+          tip_id: string;
+          user_id: string;
+          created_at?: string;
+        };
+        Update: {
+          tip_id?: string;
+          user_id?: string;
+          created_at?: string;
+        };
+      };
+      issue_tip_reports: {
+        Row: {
+          tip_id: string;
+          user_id: string;
+          reason: string | null;
+          created_at: string;
+        };
+        Insert: {
+          tip_id: string;
+          user_id: string;
+          reason?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          tip_id?: string;
+          user_id?: string;
+          reason?: string | null;
+          created_at?: string;
+        };
+      };
     };
     Views: {
       picked_issues_counts: {

--- a/messages/en.json
+++ b/messages/en.json
@@ -353,5 +353,19 @@
     "keepLocalDesc": "Keep your current local repository list",
     "useGistDesc": "Use the repository list from your cloud backup",
     "combineDesc": "Combine both repository lists"
+  },
+  "tips": {
+    "toggle": "Tips",
+    "add": "Add a tip",
+    "countLabel": "{count} tip(s)",
+    "placeholder": "Share a tip for contributors (max 280 chars)",
+    "submit": "Post",
+    "charCount": "{count}/{max}",
+    "empty": "No tips yet. Be the first!",
+    "like": "Like",
+    "report": "Report",
+    "reported": "Reported",
+    "deleteConfirm": "Delete this tip?",
+    "loginRequired": "Sign in with GitHub to share a tip."
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -366,6 +366,7 @@
     "report": "Report",
     "reported": "Reported",
     "deleteConfirm": "Delete this tip?",
-    "loginRequired": "Sign in with GitHub to share a tip."
+    "loginRequired": "Sign in with GitHub to share a tip.",
+    "submitError": "Could not post your tip. Please try again."
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -353,5 +353,19 @@
     "keepLocalDesc": "현재 로컬 저장소 목록을 유지합니다",
     "useGistDesc": "클라우드 저장소 목록을 사용합니다",
     "combineDesc": "두 저장소 목록을 합칩니다"
+  },
+  "tips": {
+    "toggle": "기여 팁",
+    "add": "팁 작성",
+    "countLabel": "팁 {count}개",
+    "placeholder": "기여자에게 도움이 될 팁을 공유하세요 (최대 280자)",
+    "submit": "등록",
+    "charCount": "{count}/{max}",
+    "empty": "아직 팁이 없습니다. 첫 팁을 남겨보세요!",
+    "like": "좋아요",
+    "report": "신고",
+    "reported": "신고됨",
+    "deleteConfirm": "이 팁을 삭제할까요?",
+    "loginRequired": "GitHub로 로그인하면 팁을 작성할 수 있습니다."
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -366,6 +366,7 @@
     "report": "신고",
     "reported": "신고됨",
     "deleteConfirm": "이 팁을 삭제할까요?",
-    "loginRequired": "GitHub로 로그인하면 팁을 작성할 수 있습니다."
+    "loginRequired": "GitHub로 로그인하면 팁을 작성할 수 있습니다.",
+    "submitError": "팁을 등록하지 못했습니다. 잠시 후 다시 시도해주세요."
   }
 }

--- a/supabase/migrations/012_create_issue_tips.sql
+++ b/supabase/migrations/012_create_issue_tips.sql
@@ -1,0 +1,138 @@
+-- Issue tips: short user-generated tips per issue (UGC)
+-- Powers #45 — beginner contributors share approach hints, gotchas, etc.
+create table issue_tips (
+  id uuid primary key default gen_random_uuid(),
+  issue_url text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  content text not null check (char_length(content) <= 280 and char_length(trim(content)) > 0),
+  like_count int not null default 0,
+  report_count int not null default 0,
+  hidden_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+-- Fast lookup of visible tips per issue
+create index idx_issue_tips_url_visible on issue_tips(issue_url, hidden_at);
+create index idx_issue_tips_user on issue_tips(user_id);
+
+alter table issue_tips enable row level security;
+
+-- Anyone (including anon) can read visible tips
+create policy "Anyone can view visible tips"
+  on issue_tips for select
+  using (hidden_at is null);
+
+-- Authors can insert their own tips
+create policy "Users can insert own tips"
+  on issue_tips for insert
+  with check (auth.uid() = user_id);
+
+-- Authors can update their own tips (e.g. for trigger-driven counter sync we use SECURITY DEFINER triggers; users editing content is out of scope but allowed)
+create policy "Users can update own tips"
+  on issue_tips for update
+  using (auth.uid() = user_id);
+
+-- Authors can delete their own tips
+create policy "Users can delete own tips"
+  on issue_tips for delete
+  using (auth.uid() = user_id);
+
+
+-- Companion: likes
+create table issue_tip_likes (
+  tip_id uuid not null references issue_tips(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (tip_id, user_id)
+);
+
+create index idx_issue_tip_likes_user on issue_tip_likes(user_id);
+
+alter table issue_tip_likes enable row level security;
+
+create policy "Anyone can view likes"
+  on issue_tip_likes for select
+  using (true);
+
+create policy "Users can like tips"
+  on issue_tip_likes for insert
+  with check (auth.uid() = user_id);
+
+create policy "Users can unlike own likes"
+  on issue_tip_likes for delete
+  using (auth.uid() = user_id);
+
+-- Trigger: keep issue_tips.like_count in sync with issue_tip_likes
+create or replace function sync_issue_tip_like_count()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if (TG_OP = 'INSERT') then
+    update issue_tips set like_count = like_count + 1 where id = NEW.tip_id;
+    return NEW;
+  elsif (TG_OP = 'DELETE') then
+    update issue_tips set like_count = greatest(like_count - 1, 0) where id = OLD.tip_id;
+    return OLD;
+  end if;
+  return null;
+end;
+$$;
+
+create trigger trg_issue_tip_likes_sync
+  after insert or delete on issue_tip_likes
+  for each row execute function sync_issue_tip_like_count();
+
+
+-- Companion: reports (one per user per tip, auto-hide at threshold)
+create table issue_tip_reports (
+  tip_id uuid not null references issue_tips(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  reason text,
+  created_at timestamptz not null default now(),
+  primary key (tip_id, user_id)
+);
+
+create index idx_issue_tip_reports_user on issue_tip_reports(user_id);
+
+alter table issue_tip_reports enable row level security;
+
+-- Reporters can see their own report (to detect duplicates client-side)
+create policy "Users can view own reports"
+  on issue_tip_reports for select
+  using (auth.uid() = user_id);
+
+create policy "Users can file reports"
+  on issue_tip_reports for insert
+  with check (auth.uid() = user_id);
+
+-- Trigger: bump report_count and hide at >= 3 reports
+create or replace function sync_issue_tip_report_count()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  new_count int;
+begin
+  update issue_tips
+    set report_count = report_count + 1
+    where id = NEW.tip_id
+    returning report_count into new_count;
+
+  if (new_count >= 3) then
+    update issue_tips
+      set hidden_at = coalesce(hidden_at, now())
+      where id = NEW.tip_id;
+  end if;
+
+  return NEW;
+end;
+$$;
+
+create trigger trg_issue_tip_reports_sync
+  after insert on issue_tip_reports
+  for each row execute function sync_issue_tip_report_count();


### PR DESCRIPTION
## Summary

- 이슈별로 280자 이내 기여 팁을 작성/조회/좋아요/신고할 수 있는 UGC 시스템 추가
- 신고 3회 누적 시 트리거가 자동으로 `hidden_at`을 채워 숨김 처리
- IssueItem 카드 하단에 접기/펼치기 형태로 통합되며, 펼칠 때 lazy fetch

## Schema (migration 012)

- `issue_tips(id, issue_url, user_id, content, like_count, report_count, hidden_at, created_at)`
  - `content` ≤ 280자, 공백 only 차단
  - 인덱스: `(issue_url, hidden_at)` — 가시 팁 조회용
- `issue_tip_likes(tip_id, user_id, created_at)` — PK `(tip_id, user_id)`
  - 트리거 `sync_issue_tip_like_count` 가 `like_count` 동기화
- `issue_tip_reports(tip_id, user_id, reason, created_at)` — PK `(tip_id, user_id)`
  - 트리거 `sync_issue_tip_report_count` 가 `report_count` 갱신, 3회 이상이면 `hidden_at` 설정
- RLS: 가시 팁 SELECT는 anon 포함 누구나, INSERT/UPDATE/DELETE는 본인만

## Changes

- `supabase/migrations/012_create_issue_tips.sql`: 신규 테이블 3종 + 트리거 2종 + RLS
- `app/api/tips/route.ts`: GET (가시 팁 목록 + 본인의 like/report 상태), POST (생성, 280자 검증), DELETE (본인 팁 삭제)
- `app/api/tips/like/route.ts`: 좋아요 토글 (POST)
- `app/api/tips/report/route.ts`: 신고 (POST, 중복 시 409)
- `app/components/IssueTips.tsx`: 접기/펼치기 UI, optimistic like/report, 글자 수 카운터, 본인 팁만 삭제 버튼
- `app/components/IssueItem.tsx`: non-compact 카드에 `<IssueTips>` 한 줄 임베드
- `app/types/supabase.ts`: 신규 테이블 3종 타입 추가
- `messages/{en,ko}.json`: `tips.*` 키 11개

## Test plan

- [ ] 마이그레이션 012 적용: `supabase db push` 후 RLS/트리거 확인
- [ ] 비로그인 상태로 이슈 카드의 "Tips" 펼치기 → 빈 상태/기존 팁 표시, 작성 폼 대신 로그인 안내 노출
- [ ] 로그인 상태로 280자 이내 팁 작성 → 즉시 목록 상단에 노출
- [ ] 281자 초과 입력 시 카운터/입력 테두리 destructive 색, 등록 버튼 비활성
- [ ] 좋아요 토글 → like_count 1↑/1↓, 새로고침 후에도 유지
- [ ] 다른 사용자 3명이 동일 팁 신고 → `hidden_at` 자동 설정, GET에서 제외됨
- [ ] 본인 팁 삭제 시 confirm 다이얼로그 후 즉시 사라짐

## Follow-up

- 팁 편집 (현재는 삭제 후 재작성만 가능)
- 페이지네이션/무한 스크롤 (MVP는 전체 표시)
- 모더레이션 대시보드 (현재는 자동 숨김만)
- 마크다운/링크 렌더링 (현재는 plain text + React 기본 escape)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)