### PR TITLE
feat: 기여자 뱃지 시스템 (#61)

### DIFF
--- a/app/(main)/picked/page.tsx
+++ b/app/(main)/picked/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { FaBookmark, FaSync, FaRegBookmark } from 'react-icons/fa';
+import BadgeGrid from '@/app/components/BadgeGrid';
 import LoginPrompt from '@/app/components/LoginPrompt';
 import PickedIssueItem from '@/app/components/PickedIssueItem';
 import PrivacyToggle from '@/app/components/PrivacyToggle';
@@ -142,6 +143,9 @@ export default function PickedPage() {
           onToggle={updatePrivacySettings}
         />
       )}
+
+      {/* Badge progress */}
+      <BadgeGrid userId={authState.userId} />
 
       {/* Issue list */}
       {pickedIssuesLoading && !refreshing ? (

--- a/app/components/BadgeGrid.tsx
+++ b/app/components/BadgeGrid.tsx
@@ -70,24 +70,35 @@ function BadgeCard({
 
 export default function BadgeGrid({ userId }: BadgeGridProps) {
   const t = useTranslations();
-  const { earned } = useUserBadges(userId);
+  const { earned, loading } = useUserBadges(userId);
 
   const earnedById = new Map(earned.map(b => [b.badgeId, b]));
   const earnedCount = earned.length;
   const total = BADGE_DEFINITIONS.length;
+  // Suppress the locked-grid flicker on the very first fetch — once we have any
+  // badges (or a finished load), render the real grid even while refreshing.
+  const showSkeleton = loading && earned.length === 0;
 
   return (
     <section className="rounded-lg border border-border bg-card p-4">
       <div className="mb-3 flex items-center justify-between">
         <h3 className="text-sm font-semibold text-foreground">{t('badge.gridTitle')}</h3>
         <span className="text-xs text-muted-foreground">
-          {t('badge.progress', { earned: earnedCount, total })}
+          {showSkeleton ? '…' : t('badge.progress', { earned: earnedCount, total })}
         </span>
       </div>
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        {BADGE_DEFINITIONS.map(badge => (
-          <BadgeCard key={badge.id} badge={badge} earned={earnedById.get(badge.id)} />
-        ))}
+        {showSkeleton
+          ? BADGE_DEFINITIONS.map(badge => (
+              <div
+                key={badge.id}
+                className="h-[120px] rounded-lg border border-dashed border-border/40 bg-muted/20 animate-pulse"
+                aria-hidden
+              />
+            ))
+          : BADGE_DEFINITIONS.map(badge => (
+              <BadgeCard key={badge.id} badge={badge} earned={earnedById.get(badge.id)} />
+            ))}
       </div>
     </section>
   );

--- a/app/components/BadgeGrid.tsx
+++ b/app/components/BadgeGrid.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Sparkles, GitMerge, Languages, Compass, Lock } from 'lucide-react';
+import { BADGE_DEFINITIONS, type BadgeDefinition } from '@/app/lib/badges/definitions';
+import useUserBadges, { type EarnedBadge } from '@/app/hooks/useUserBadges';
+
+interface BadgeGridProps {
+  userId?: string;
+}
+
+const ICON_MAP = {
+  sparkles: Sparkles,
+  'git-merge': GitMerge,
+  languages: Languages,
+  compass: Compass,
+} as const;
+
+function BadgeCard({
+  badge,
+  earned,
+}: {
+  badge: BadgeDefinition;
+  earned: EarnedBadge | undefined;
+}) {
+  // Badge keys are dynamic strings derived from the catalog; next-intl's typed
+  // useTranslations expects literal keys, so we widen the signature locally.
+  const t = useTranslations() as unknown as (
+    key: string,
+    values?: Record<string, string | number>,
+  ) => string;
+  const Icon = ICON_MAP[badge.icon];
+  const isUnlocked = Boolean(earned);
+
+  return (
+    <div
+      className={`relative flex flex-col items-center gap-2 rounded-lg border p-3 text-center transition ${
+        isUnlocked
+          ? 'border-border bg-card'
+          : 'border-dashed border-border/60 bg-muted/30'
+      }`}
+      aria-label={
+        isUnlocked ? t(badge.nameKey) : `${t(badge.nameKey)} - ${t('badge.locked')}`
+      }
+    >
+      <div
+        className={`flex h-12 w-12 items-center justify-center rounded-full ${
+          isUnlocked
+            ? `bg-gradient-to-br ${badge.gradient} text-white shadow-sm`
+            : 'bg-muted text-muted-foreground'
+        }`}
+      >
+        {isUnlocked ? <Icon className="h-6 w-6" /> : <Lock className="h-5 w-5" />}
+      </div>
+      <div className="space-y-0.5">
+        <p
+          className={`text-xs font-semibold ${
+            isUnlocked ? 'text-foreground' : 'text-muted-foreground'
+          }`}
+        >
+          {t(badge.nameKey)}
+        </p>
+        <p className="text-[10px] leading-tight text-muted-foreground line-clamp-2">
+          {t(badge.descriptionKey)}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function BadgeGrid({ userId }: BadgeGridProps) {
+  const t = useTranslations();
+  const { earned } = useUserBadges(userId);
+
+  const earnedById = new Map(earned.map(b => [b.badgeId, b]));
+  const earnedCount = earned.length;
+  const total = BADGE_DEFINITIONS.length;
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-foreground">{t('badge.gridTitle')}</h3>
+        <span className="text-xs text-muted-foreground">
+          {t('badge.progress', { earned: earnedCount, total })}
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {BADGE_DEFINITIONS.map(badge => (
+          <BadgeCard key={badge.id} badge={badge} earned={earnedById.get(badge.id)} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/hooks/usePickedIssues.ts
+++ b/app/hooks/usePickedIssues.ts
@@ -212,9 +212,20 @@ const usePickedIssues = (
               );
               if (result.verified) {
                 const verifiedAt = new Date().toISOString();
+                // Repository labels often carry the language as a label (e.g.
+                // "JavaScript", "Python"). Best-effort lookup so the polyglot
+                // badge can count distinct languages without a separate API call.
+                const languageLabel = picked.labels.find(l =>
+                  /^(javascript|typescript|python|go|rust|java|ruby|c\+\+|c#|php|swift|kotlin)$/i.test(
+                    l.name,
+                  ),
+                )?.name;
                 void logActivityEvent(userId, 'contribution_completed', {
                   issue_id: picked.id,
                   issue_url: picked.url,
+                  repository_owner: picked.repository.owner,
+                  repository_name: picked.repository.name,
+                  language: languageLabel ?? null,
                   closing_pr_url: result.closingPrUrl ?? null,
                   closing_pr_author: result.closingPrAuthor ?? null,
                 });

--- a/app/hooks/usePickedIssues.ts
+++ b/app/hooks/usePickedIssues.ts
@@ -21,6 +21,45 @@ interface StateChange {
   to: string | undefined;
 }
 
+// Canonical names matched in any case. Common GitHub label patterns we accept:
+//   "JavaScript", "lang:python", "language:rust", "language/go".
+const LANGUAGE_NAMES = [
+  'javascript',
+  'typescript',
+  'python',
+  'go',
+  'rust',
+  'java',
+  'ruby',
+  'c++',
+  'c#',
+  'php',
+  'swift',
+  'kotlin',
+  'dart',
+  'scala',
+  'elixir',
+  'haskell',
+  'shell',
+  'html',
+  'css',
+] as const;
+
+const LANGUAGE_LABEL_RE = new RegExp(
+  `^(?:lang|language)?[:/\\-\\s]?\\s*(${LANGUAGE_NAMES.map(n => n.replace(/[+#]/g, '\\$&')).join('|')})$`,
+  'i',
+);
+
+function detectLanguageFromLabels(
+  labels: ReadonlyArray<{ name: string }>,
+): string | null {
+  for (const label of labels) {
+    const m = LANGUAGE_LABEL_RE.exec(label.name);
+    if (m) return m[1].toLowerCase();
+  }
+  return null;
+}
+
 // Process items in batches to avoid rate limits
 async function batchProcess<T, R>(
   items: T[],
@@ -212,20 +251,12 @@ const usePickedIssues = (
               );
               if (result.verified) {
                 const verifiedAt = new Date().toISOString();
-                // Repository labels often carry the language as a label (e.g.
-                // "JavaScript", "Python"). Best-effort lookup so the polyglot
-                // badge can count distinct languages without a separate API call.
-                const languageLabel = picked.labels.find(l =>
-                  /^(javascript|typescript|python|go|rust|java|ruby|c\+\+|c#|php|swift|kotlin)$/i.test(
-                    l.name,
-                  ),
-                )?.name;
                 void logActivityEvent(userId, 'contribution_completed', {
                   issue_id: picked.id,
                   issue_url: picked.url,
                   repository_owner: picked.repository.owner,
                   repository_name: picked.repository.name,
-                  language: languageLabel ?? null,
+                  language: detectLanguageFromLabels(picked.labels),
                   closing_pr_url: result.closingPrUrl ?? null,
                   closing_pr_author: result.closingPrAuthor ?? null,
                 });

--- a/app/hooks/useUserBadges.ts
+++ b/app/hooks/useUserBadges.ts
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useState } from 'react';
+import { createClient } from '@/app/lib/supabase/client';
+import { Database } from '@/app/types/supabase';
+
+type UserBadgeRow = Database['public']['Tables']['user_badges']['Row'];
+
+export interface EarnedBadge {
+  badgeId: string;
+  earnedAt: string;
+  metadata: Record<string, unknown>;
+}
+
+interface UseUserBadgesResult {
+  earned: EarnedBadge[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Load badges granted to `userId`. Returns empty list when no userId is
+ * provided so callers can render the locked state without conditional hooks.
+ */
+export default function useUserBadges(userId?: string): UseUserBadgesResult {
+  const [earned, setEarned] = useState<EarnedBadge[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchBadges = useCallback(async (uid: string) => {
+    const supabase = createClient();
+    const { data, error: queryError } = await supabase
+      .from('user_badges')
+      .select('badge_id, earned_at, metadata')
+      .eq('user_id', uid)
+      .order('earned_at', { ascending: true });
+
+    if (queryError) {
+      console.error('[useUserBadges] fetch failed:', queryError);
+      throw queryError;
+    }
+
+    const rows = (data ?? []) as Pick<
+      UserBadgeRow,
+      'badge_id' | 'earned_at' | 'metadata'
+    >[];
+    return rows.map(
+      (row): EarnedBadge => ({
+        badgeId: row.badge_id,
+        earnedAt: row.earned_at,
+        metadata:
+          row.metadata && typeof row.metadata === 'object' && !Array.isArray(row.metadata)
+            ? (row.metadata as Record<string, unknown>)
+            : {},
+      }),
+    );
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (!userId) {
+      setEarned([]);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await fetchBadges(userId);
+      setEarned(next);
+    } catch {
+      setError('Failed to load badges');
+    } finally {
+      setLoading(false);
+    }
+  }, [userId, fetchBadges]);
+
+  useEffect(() => {
+    if (!userId) {
+      setEarned([]);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchBadges(userId)
+      .then(rows => {
+        if (!cancelled) setEarned(rows);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Failed to load badges');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, fetchBadges]);
+
+  return { earned, loading, error, refresh };
+}

--- a/app/lib/badges/definitions.ts
+++ b/app/lib/badges/definitions.ts
@@ -1,0 +1,53 @@
+// Badge catalog (#61).
+// IDs are persisted in Supabase `user_badges.badge_id` and emitted in
+// `badge_earned` activity event payloads. Keep in sync with
+// supabase/migrations/011_create_user_badges.sql.
+
+export type BadgeId = 'first_pick' | 'first_merge' | 'polyglot' | 'explorer';
+
+export interface BadgeDefinition {
+  id: BadgeId;
+  /** i18n key under `badge.<id>.name` */
+  nameKey: string;
+  /** i18n key under `badge.<id>.description` */
+  descriptionKey: string;
+  /** Lucide icon name — caller imports the matching component */
+  icon: 'sparkles' | 'git-merge' | 'languages' | 'compass';
+  /** Tailwind gradient classes for the unlocked state */
+  gradient: string;
+}
+
+export const BADGE_DEFINITIONS: readonly BadgeDefinition[] = [
+  {
+    id: 'first_pick',
+    nameKey: 'badge.first_pick.name',
+    descriptionKey: 'badge.first_pick.description',
+    icon: 'sparkles',
+    gradient: 'from-amber-400 to-orange-500',
+  },
+  {
+    id: 'first_merge',
+    nameKey: 'badge.first_merge.name',
+    descriptionKey: 'badge.first_merge.description',
+    icon: 'git-merge',
+    gradient: 'from-emerald-400 to-teal-500',
+  },
+  {
+    id: 'polyglot',
+    nameKey: 'badge.polyglot.name',
+    descriptionKey: 'badge.polyglot.description',
+    icon: 'languages',
+    gradient: 'from-fuchsia-400 to-purple-500',
+  },
+  {
+    id: 'explorer',
+    nameKey: 'badge.explorer.name',
+    descriptionKey: 'badge.explorer.description',
+    icon: 'compass',
+    gradient: 'from-sky-400 to-blue-500',
+  },
+] as const;
+
+export function getBadgeDefinition(id: string): BadgeDefinition | undefined {
+  return BADGE_DEFINITIONS.find(b => b.id === id);
+}

--- a/app/lib/badges/evaluator.ts
+++ b/app/lib/badges/evaluator.ts
@@ -1,0 +1,22 @@
+import { createClient } from '@/app/lib/supabase/client';
+
+/**
+ * Manually trigger badge re-evaluation for a user.
+ *
+ * The Supabase trigger on user_activity_events normally handles this in-band,
+ * but this helper exists as a fallback for backfill scripts or if the trigger
+ * is disabled. Safe to call repeatedly — the underlying SQL uses
+ * `on conflict do nothing`.
+ */
+export async function reevaluateUserBadges(userId: string): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase.rpc(
+    'evaluate_user_badges' as never,
+    {
+      p_user_id: userId,
+    } as never,
+  );
+  if (error) {
+    console.error('[badges] evaluate_user_badges rpc failed:', error);
+  }
+}

--- a/app/types/supabase.ts
+++ b/app/types/supabase.ts
@@ -93,6 +93,26 @@ export interface Database {
           created_at?: string;
         };
       };
+      user_badges: {
+        Row: {
+          user_id: string;
+          badge_id: string;
+          earned_at: string;
+          metadata: Json;
+        };
+        Insert: {
+          user_id: string;
+          badge_id: string;
+          earned_at?: string;
+          metadata?: Json;
+        };
+        Update: {
+          user_id?: string;
+          badge_id?: string;
+          earned_at?: string;
+          metadata?: Json;
+        };
+      };
       picked_issues: {
         Row: {
           id: string;

--- a/messages/en.json
+++ b/messages/en.json
@@ -279,6 +279,27 @@
       "never": "Never"
     }
   },
+  "badge": {
+    "gridTitle": "Contributor Badges",
+    "locked": "Locked",
+    "progress": "{earned}/{total} earned",
+    "first_pick": {
+      "name": "First Pick",
+      "description": "Picked your first issue"
+    },
+    "first_merge": {
+      "name": "First Merge",
+      "description": "Closed an issue with your own PR"
+    },
+    "polyglot": {
+      "name": "Polyglot",
+      "description": "Contributed in 3+ languages"
+    },
+    "explorer": {
+      "name": "Explorer",
+      "description": "Contributed to 5+ repositories"
+    }
+  },
   "profile": {
     "title": "Your Profile",
     "analyzing": "Analyzing your GitHub profile...",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -279,6 +279,27 @@
       "never": "안 함"
     }
   },
+  "badge": {
+    "gridTitle": "기여자 뱃지",
+    "locked": "잠김",
+    "progress": "{earned}/{total} 획득",
+    "first_pick": {
+      "name": "첫 Pick",
+      "description": "첫 번째 이슈를 Pick했습니다"
+    },
+    "first_merge": {
+      "name": "첫 머지",
+      "description": "내 PR로 이슈를 닫았습니다"
+    },
+    "polyglot": {
+      "name": "다국어 기여자",
+      "description": "3개 이상 언어로 기여했습니다"
+    },
+    "explorer": {
+      "name": "탐험가",
+      "description": "5개 이상 저장소에 기여했습니다"
+    }
+  },
   "profile": {
     "title": "내 프로필",
     "analyzing": "GitHub 프로필 분석 중...",

--- a/supabase/migrations/011_create_user_badges.sql
+++ b/supabase/migrations/011_create_user_badges.sql
@@ -89,66 +89,75 @@ begin
   end if;
 
   -- 3. polyglot — contribution_completed events spanning >= 3 distinct languages.
-  --    Languages are read from payload->>'language'; events without that field
-  --    do not count. NULL/empty values filtered out.
-  select count(distinct nullif(payload->>'language', ''))
-  into v_distinct_languages
-  from user_activity_events
-  where user_id = p_user_id
-    and event_type = 'contribution_completed'
-    and payload ? 'language';
+  --    Skip the count(distinct …) scan once the badge is owned. lower() makes
+  --    the count case-insensitive in case payload writers vary in casing.
+  if not exists (
+    select 1 from user_badges
+    where user_id = p_user_id and badge_id = 'polyglot'
+  ) then
+    select count(distinct lower(nullif(payload->>'language', '')))
+    into v_distinct_languages
+    from user_activity_events
+    where user_id = p_user_id
+      and event_type = 'contribution_completed'
+      and payload ? 'language';
 
-  if coalesce(v_distinct_languages, 0) >= 3 then
-    insert into user_badges (user_id, badge_id, metadata)
-      values (
-        p_user_id,
-        'polyglot',
-        jsonb_build_object('language_count', v_distinct_languages)
-      )
-      on conflict do nothing
-      returning true into v_inserted;
-    if v_inserted then
-      insert into user_activity_events (user_id, event_type, payload)
-        values (p_user_id, 'badge_earned', jsonb_build_object(
-          'badge_id', 'polyglot',
-          'name_key', 'badge.polyglot.name',
-          'language_count', v_distinct_languages
-        ));
+    if coalesce(v_distinct_languages, 0) >= 3 then
+      insert into user_badges (user_id, badge_id, metadata)
+        values (
+          p_user_id,
+          'polyglot',
+          jsonb_build_object('language_count', v_distinct_languages)
+        )
+        on conflict do nothing
+        returning true into v_inserted;
+      if v_inserted then
+        insert into user_activity_events (user_id, event_type, payload)
+          values (p_user_id, 'badge_earned', jsonb_build_object(
+            'badge_id', 'polyglot',
+            'name_key', 'badge.polyglot.name',
+            'language_count', v_distinct_languages
+          ));
+      end if;
+      v_inserted := null;
     end if;
-    v_inserted := null;
   end if;
 
   -- 4. explorer — contribution_completed events to >= 5 distinct repos.
-  --    Repo identity = "owner/name" derived from payload fields written by
-  --    the client (see app/hooks/usePickedIssues.ts). Falls back to empty
-  --    string which gets filtered.
-  select count(distinct nullif(
-    coalesce(payload->>'repository_owner', '') ||
-    '/' ||
-    coalesce(payload->>'repository_name', ''),
-    '/'
-  ))
-  into v_distinct_repos
-  from user_activity_events
-  where user_id = p_user_id
-    and event_type = 'contribution_completed';
+  --    Same IF NOT EXISTS optimization. Repo identity is lower-cased so
+  --    "Owner/Repo" and "owner/repo" don't double-count.
+  if not exists (
+    select 1 from user_badges
+    where user_id = p_user_id and badge_id = 'explorer'
+  ) then
+    select count(distinct lower(nullif(
+      coalesce(payload->>'repository_owner', '') ||
+      '/' ||
+      coalesce(payload->>'repository_name', ''),
+      '/'
+    )))
+    into v_distinct_repos
+    from user_activity_events
+    where user_id = p_user_id
+      and event_type = 'contribution_completed';
 
-  if coalesce(v_distinct_repos, 0) >= 5 then
-    insert into user_badges (user_id, badge_id, metadata)
-      values (
-        p_user_id,
-        'explorer',
-        jsonb_build_object('repo_count', v_distinct_repos)
-      )
-      on conflict do nothing
-      returning true into v_inserted;
-    if v_inserted then
-      insert into user_activity_events (user_id, event_type, payload)
-        values (p_user_id, 'badge_earned', jsonb_build_object(
-          'badge_id', 'explorer',
-          'name_key', 'badge.explorer.name',
-          'repo_count', v_distinct_repos
-        ));
+    if coalesce(v_distinct_repos, 0) >= 5 then
+      insert into user_badges (user_id, badge_id, metadata)
+        values (
+          p_user_id,
+          'explorer',
+          jsonb_build_object('repo_count', v_distinct_repos)
+        )
+        on conflict do nothing
+        returning true into v_inserted;
+      if v_inserted then
+        insert into user_activity_events (user_id, event_type, payload)
+          values (p_user_id, 'badge_earned', jsonb_build_object(
+            'badge_id', 'explorer',
+            'name_key', 'badge.explorer.name',
+            'repo_count', v_distinct_repos
+          ));
+      end if;
     end if;
   end if;
 end;

--- a/supabase/migrations/011_create_user_badges.sql
+++ b/supabase/migrations/011_create_user_badges.sql
@@ -1,0 +1,184 @@
+-- Contributor badge system (#61)
+-- Stores granted badges per user and emits `badge_earned` activity events.
+-- Trigger evaluates eligibility AFTER INSERT on user_activity_events so the
+-- badge is granted in the same transaction as the qualifying action.
+
+create table if not exists user_badges (
+  user_id text not null references user_profiles(id) on delete cascade,
+  badge_id text not null,
+  earned_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb,
+  primary key (user_id, badge_id)
+);
+
+create index if not exists idx_user_badges_user
+  on user_badges(user_id, earned_at desc);
+
+-- RLS: users see their own badges + badges of opted-in public profiles
+alter table user_badges enable row level security;
+
+create policy "Users can view own or public badges"
+  on user_badges for select
+  using (
+    auth.uid()::text = user_id
+    or exists (
+      select 1 from user_profiles up
+      where up.id = user_badges.user_id and up.is_public = true
+    )
+  );
+
+-- Inserts come from the trigger (security definer); no client-side insert/update/delete.
+
+-- ----------------------------------------------------------------------------
+-- Evaluation function
+--
+-- For each defined badge, check the user's activity history. If the user
+-- qualifies and doesn't yet have the badge, insert into user_badges and emit
+-- a `badge_earned` activity event. ON CONFLICT DO NOTHING keeps re-evaluation
+-- idempotent.
+-- ----------------------------------------------------------------------------
+create or replace function evaluate_user_badges(p_user_id text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_inserted boolean;
+  v_distinct_languages int;
+  v_distinct_repos int;
+begin
+  -- 1. first_pick — first issue_picked event
+  if exists (
+    select 1 from user_activity_events
+    where user_id = p_user_id and event_type = 'issue_picked'
+    limit 1
+  ) then
+    insert into user_badges (user_id, badge_id)
+      values (p_user_id, 'first_pick')
+      on conflict do nothing
+      returning true into v_inserted;
+    if v_inserted then
+      insert into user_activity_events (user_id, event_type, payload)
+        values (p_user_id, 'badge_earned', jsonb_build_object(
+          'badge_id', 'first_pick',
+          'name_key', 'badge.first_pick.name'
+        ));
+    end if;
+    v_inserted := null;
+  end if;
+
+  -- 2. first_merge — first contribution_completed event
+  if exists (
+    select 1 from user_activity_events
+    where user_id = p_user_id and event_type = 'contribution_completed'
+    limit 1
+  ) then
+    insert into user_badges (user_id, badge_id)
+      values (p_user_id, 'first_merge')
+      on conflict do nothing
+      returning true into v_inserted;
+    if v_inserted then
+      insert into user_activity_events (user_id, event_type, payload)
+        values (p_user_id, 'badge_earned', jsonb_build_object(
+          'badge_id', 'first_merge',
+          'name_key', 'badge.first_merge.name'
+        ));
+    end if;
+    v_inserted := null;
+  end if;
+
+  -- 3. polyglot — contribution_completed events spanning >= 3 distinct languages.
+  --    Languages are read from payload->>'language'; events without that field
+  --    do not count. NULL/empty values filtered out.
+  select count(distinct nullif(payload->>'language', ''))
+  into v_distinct_languages
+  from user_activity_events
+  where user_id = p_user_id
+    and event_type = 'contribution_completed'
+    and payload ? 'language';
+
+  if coalesce(v_distinct_languages, 0) >= 3 then
+    insert into user_badges (user_id, badge_id, metadata)
+      values (
+        p_user_id,
+        'polyglot',
+        jsonb_build_object('language_count', v_distinct_languages)
+      )
+      on conflict do nothing
+      returning true into v_inserted;
+    if v_inserted then
+      insert into user_activity_events (user_id, event_type, payload)
+        values (p_user_id, 'badge_earned', jsonb_build_object(
+          'badge_id', 'polyglot',
+          'name_key', 'badge.polyglot.name',
+          'language_count', v_distinct_languages
+        ));
+    end if;
+    v_inserted := null;
+  end if;
+
+  -- 4. explorer — contribution_completed events to >= 5 distinct repos.
+  --    Repo identity = "owner/name" derived from payload fields written by
+  --    the client (see app/hooks/usePickedIssues.ts). Falls back to empty
+  --    string which gets filtered.
+  select count(distinct nullif(
+    coalesce(payload->>'repository_owner', '') ||
+    '/' ||
+    coalesce(payload->>'repository_name', ''),
+    '/'
+  ))
+  into v_distinct_repos
+  from user_activity_events
+  where user_id = p_user_id
+    and event_type = 'contribution_completed';
+
+  if coalesce(v_distinct_repos, 0) >= 5 then
+    insert into user_badges (user_id, badge_id, metadata)
+      values (
+        p_user_id,
+        'explorer',
+        jsonb_build_object('repo_count', v_distinct_repos)
+      )
+      on conflict do nothing
+      returning true into v_inserted;
+    if v_inserted then
+      insert into user_activity_events (user_id, event_type, payload)
+        values (p_user_id, 'badge_earned', jsonb_build_object(
+          'badge_id', 'explorer',
+          'name_key', 'badge.explorer.name',
+          'repo_count', v_distinct_repos
+        ));
+    end if;
+  end if;
+end;
+$$;
+
+-- ----------------------------------------------------------------------------
+-- Trigger: re-evaluate badges after a relevant activity event is inserted.
+-- Skips `badge_earned` itself to avoid recursion.
+-- ----------------------------------------------------------------------------
+create or replace function trigger_evaluate_user_badges()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.event_type in ('issue_picked', 'contribution_completed') then
+    perform evaluate_user_badges(new.user_id);
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists user_activity_events_evaluate_badges on user_activity_events;
+
+create trigger user_activity_events_evaluate_badges
+  after insert on user_activity_events
+  for each row
+  execute function trigger_evaluate_user_badges();
+
+-- Grant execute on the evaluator so service-role and authenticated callers can
+-- invoke a manual re-evaluation if needed (e.g. backfill script).
+grant execute on function evaluate_user_badges(text) to authenticated, service_role;


### PR DESCRIPTION
## Summary

- 활동 이벤트 기반 자동 평가 뱃지 시스템 — `first_pick`, `first_merge`, `polyglot`, `explorer`
- `user_activity_events` INSERT 시 트리거가 즉시 평가 후 `user_badges`에 grant
- 신규 grant 시 `badge_earned` 활동 이벤트를 함께 발행 (#66 피드와 연동)
- `/picked` 페이지 상단에 BadgeGrid 추가 (잠금/해제 상태 표시)

## Schema (migration 011_create_user_badges.sql)

- `user_badges (user_id, badge_id, earned_at, metadata jsonb)` — composite PK로 멱등성 확보
- RLS: 본인 + `is_public=true` 프로필의 뱃지를 select 가능 (insert/update/delete는 트리거 전용)
- `evaluate_user_badges(p_user_id text)` SECURITY DEFINER 함수 — 4개 뱃지 일괄 평가
- `trigger_evaluate_user_badges` AFTER INSERT trigger — `issue_picked` / `contribution_completed` 이벤트에만 실행 (recursion 방지)

## Changes

- `app/lib/badges/definitions.ts` — 뱃지 카탈로그 (id/icon/gradient/i18n key)
- `app/lib/badges/evaluator.ts` — `reevaluateUserBadges(userId)` 백필 helper
- `app/components/BadgeGrid.tsx` — 잠금/해제 상태별 카드 그리드 + 진행도 표시
- `app/hooks/useUserBadges.ts` — Supabase 쿼리 hook
- `app/(main)/picked/page.tsx` — BadgeGrid 통합 (한 줄)
- `app/hooks/usePickedIssues.ts` — `contribution_completed` 페이로드에 `repository_owner/name`, `language` 추가 (polyglot/explorer 평가 기반)
- `app/types/supabase.ts` — `user_badges` 타입 추가
- `messages/{en,ko}.json` — `badge.*` 키 (gridTitle, locked, progress, 4개 뱃지 name/description)

## Test plan

- [ ] `/picked` 비로그인 → BadgeGrid 노출 안 됨 (페이지 자체가 LoginPrompt)
- [ ] 첫 pick 후 `first_pick` 뱃지 즉시 잠금 해제 확인
- [ ] 기여 완료 자동 검증 트리거 후 `first_merge` grant + `badge_earned` 이벤트 로깅
- [ ] 동일 액션 반복 시 중복 grant 없음 (ON CONFLICT DO NOTHING)
- [ ] `is_public=false` 사용자의 뱃지가 다른 사용자에게 노출 안 됨

## Follow-up

- 뱃지 획득 축하 모달 (Wave 2B)
- 공개 프로필 페이지의 뱃지 위젯 (#62)
- 추가 뱃지 (issue 다양성, 연속 기여 등) — 별도 이슈로

## Verification

- `npx tsc --noEmit`: clean
- `npx eslint <changed files>`: 0 errors
- `npm run build`: success (모든 페이지 prerender, /picked 빌드 OK)

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)