### PR TITLE
feat: SSR 레포지토리 랜딩 페이지 (#85)

### DIFF
--- a/app/(main)/repos/[owner]/[name]/RepoLandingClient.tsx
+++ b/app/(main)/repos/[owner]/[name]/RepoLandingClient.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import React, { useState } from 'react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { FaGithub, FaBookmark } from 'react-icons/fa';
+import { LuShield, LuLightbulb, LuExternalLink } from 'react-icons/lu';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { formatRelativeTime } from '@/app/utils/formatRelativeTime';
+import { useLocaleSwitch } from '@/app/providers/IntlProvider';
+import type { RepoIssue, RepoTip, MaintainerScoreData } from './page';
+
+interface RepoLandingClientProps {
+  owner: string;
+  name: string;
+  issues: RepoIssue[];
+  tips: RepoTip[];
+  maintainerScore: MaintainerScoreData | null;
+}
+
+const maintainerGradeStyles = {
+  A: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
+  B: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
+  C: 'bg-muted text-muted-foreground border-border',
+};
+
+type TipSort = 'popular' | 'recent';
+
+export default function RepoLandingClient({
+  owner,
+  name,
+  issues,
+  tips,
+  maintainerScore,
+}: RepoLandingClientProps) {
+  const t = useTranslations('repoLanding');
+  const tMaintainer = useTranslations('maintainer');
+  const tCommon = useTranslations('common');
+  const { locale } = useLocaleSwitch();
+  const [tipSort, setTipSort] = useState<TipSort>('popular');
+
+  const sortedTips =
+    tipSort === 'popular'
+      ? [...tips].sort((a, b) => b.likeCount - a.likeCount)
+      : [...tips].sort(
+          (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        );
+
+  return (
+    <div className="space-y-8 max-w-3xl mx-auto">
+      {/* Header */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Link href="/issues" className="hover:text-foreground transition-colors">
+            {tCommon('issues')}
+          </Link>
+          <span>/</span>
+          <span>{owner}</span>
+          <span>/</span>
+          <span className="text-foreground font-medium">{name}</span>
+        </div>
+
+        <h1 className="text-2xl font-bold text-foreground">
+          {t('heading', { owner, name })}
+        </h1>
+
+        <div className="flex items-center gap-3 flex-wrap">
+          <a
+            href={`https://github.com/${owner}/${name}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <FaGithub className="size-4" />
+            {owner}/{name}
+            <LuExternalLink className="size-3" />
+          </a>
+
+          {maintainerScore && (
+            <Badge
+              variant="outline"
+              className={cn(
+                'inline-flex items-center gap-1.5 text-xs px-2 py-1 rounded',
+                maintainerGradeStyles[maintainerScore.grade],
+              )}
+              title={`${tMaintainer(`grade${maintainerScore.grade}`)} · ${tMaintainer('responseTime', { hours: Math.round(maintainerScore.avgResponseTimeHours) })} · ${tMaintainer('mergeRate', { rate: Math.round(maintainerScore.mergeRate * 100) })}`}
+            >
+              <LuShield className="size-3.5 shrink-0" />
+              {maintainerScore.grade} · {tMaintainer(`grade${maintainerScore.grade}`)}
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      {/* Beginner-friendly issues */}
+      <section aria-labelledby="issues-heading">
+        <h2
+          id="issues-heading"
+          className="text-lg font-semibold text-foreground mb-4 flex items-center gap-2"
+        >
+          <FaBookmark className="size-4 text-primary" />
+          {t('issuesHeading')}
+          {issues.length > 0 && (
+            <span className="text-sm font-normal text-muted-foreground">
+              ({issues.length})
+            </span>
+          )}
+        </h2>
+
+        {issues.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('noIssues')}</p>
+        ) : (
+          <ul className="space-y-2">
+            {issues.map(issue => (
+              <li key={issue.issueUrl}>
+                <Card className="p-3 rounded-lg border-border gap-0 hover:border-border/80 transition-colors">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex-1 min-w-0">
+                      <a
+                        href={issue.issueUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm font-medium text-foreground hover:text-primary transition-colors line-clamp-2"
+                      >
+                        <span className="font-mono text-muted-foreground text-xs mr-1">
+                          #{issue.issueNumber}
+                        </span>
+                        {issue.title}
+                      </a>
+                    </div>
+                    {issue.pickCount > 0 && (
+                      <Badge
+                        variant="outline"
+                        className="shrink-0 inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded border-border bg-muted text-muted-foreground"
+                      >
+                        <FaBookmark className="size-2.5" />
+                        {issue.pickCount}
+                      </Badge>
+                    )}
+                  </div>
+                </Card>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Contributor tips */}
+      <section aria-labelledby="tips-heading">
+        <div className="flex items-center justify-between mb-4 flex-wrap gap-2">
+          <h2
+            id="tips-heading"
+            className="text-lg font-semibold text-foreground flex items-center gap-2"
+          >
+            <LuLightbulb className="size-4 text-amber-400" />
+            {t('tipsHeading')}
+            {tips.length > 0 && (
+              <span className="text-sm font-normal text-muted-foreground">
+                ({tips.length})
+              </span>
+            )}
+          </h2>
+
+          {tips.length > 1 && (
+            <div className="inline-flex rounded-md border border-border overflow-hidden text-xs">
+              <button
+                type="button"
+                onClick={() => setTipSort('popular')}
+                className={cn(
+                  'px-3 py-1.5 transition-colors',
+                  tipSort === 'popular'
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-accent',
+                )}
+              >
+                {t('tipsSortPopular')}
+              </button>
+              <button
+                type="button"
+                onClick={() => setTipSort('recent')}
+                className={cn(
+                  'px-3 py-1.5 transition-colors border-l border-border',
+                  tipSort === 'recent'
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-accent',
+                )}
+              >
+                {t('tipsSortRecent')}
+              </button>
+            </div>
+          )}
+        </div>
+
+        {tips.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('noTips')}</p>
+        ) : (
+          <ul className="space-y-2">
+            {sortedTips.map(tip => (
+              <li
+                key={tip.id}
+                className="rounded-lg border border-border bg-muted/40 p-3"
+              >
+                <p className="text-sm text-foreground whitespace-pre-wrap break-words">
+                  {tip.content}
+                </p>
+                <div className="mt-2 flex items-center gap-3 text-xs text-muted-foreground">
+                  <span>{formatRelativeTime(tip.createdAt, tCommon, locale)}</span>
+                  {tip.likeCount > 0 && (
+                    <span className="inline-flex items-center gap-1">
+                      <span>+{tip.likeCount}</span>
+                    </span>
+                  )}
+                  <a
+                    href={tip.issueUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="hover:text-foreground transition-colors truncate max-w-[200px]"
+                  >
+                    #{tip.issueUrl.split('/').pop()}
+                  </a>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* CTA to browse issues */}
+      <div className="rounded-lg border border-border bg-muted/30 p-4 text-center space-y-2">
+        <p className="text-sm text-muted-foreground">{t('ctaDesc')}</p>
+        <Link
+          href="/issues"
+          className="inline-flex items-center gap-1.5 text-sm text-primary hover:text-primary/80 transition-colors font-medium"
+        >
+          {t('ctaLink')}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/repos/[owner]/[name]/RepoLandingClient.tsx
+++ b/app/(main)/repos/[owner]/[name]/RepoLandingClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { FaGithub, FaBookmark } from 'react-icons/fa';
@@ -41,10 +41,13 @@ export default function RepoLandingClient({
   const { locale } = useLocaleSwitch();
   const [tipSort, setTipSort] = useState<TipSort>('popular');
 
-  const sortedTips =
-    tipSort === 'popular'
-      ? [...tips].sort((a, b) => b.likeCount - a.likeCount)
-      : [...tips].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  const sortedTips = useMemo(
+    () =>
+      tipSort === 'popular'
+        ? [...tips].sort((a, b) => b.likeCount - a.likeCount)
+        : [...tips].sort((a, b) => b.createdAt.localeCompare(a.createdAt)),
+    [tips, tipSort],
+  );
 
   return (
     <div className="space-y-8 max-w-3xl mx-auto">

--- a/app/(main)/repos/[owner]/[name]/RepoLandingClient.tsx
+++ b/app/(main)/repos/[owner]/[name]/RepoLandingClient.tsx
@@ -44,9 +44,7 @@ export default function RepoLandingClient({
   const sortedTips =
     tipSort === 'popular'
       ? [...tips].sort((a, b) => b.likeCount - a.likeCount)
-      : [...tips].sort(
-          (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-        );
+      : [...tips].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
 
   return (
     <div className="space-y-8 max-w-3xl mx-auto">

--- a/app/(main)/repos/[owner]/[name]/page.tsx
+++ b/app/(main)/repos/[owner]/[name]/page.tsx
@@ -115,7 +115,9 @@ async function fetchRepoData(owner: string, repoName: string) {
 
   const issues: RepoIssue[] = ((issuesData as PickedIssueRow[] | null) ?? []).map(r => ({
     issueUrl: r.issue_url,
-    issueNumber: Number(r.issue_number ?? r.issue_url.split('/').pop() ?? 0),
+    issueNumber: Number(
+      r.issue_number ?? r.issue_url.replace(/\/$/, '').split('/').pop() ?? 0,
+    ),
     title: r.title,
     labels: [],
     pickCount: Number(r.pick_count),

--- a/app/(main)/repos/[owner]/[name]/page.tsx
+++ b/app/(main)/repos/[owner]/[name]/page.tsx
@@ -1,0 +1,208 @@
+import { notFound } from 'next/navigation';
+import { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { createClient } from '@/app/lib/supabase/server';
+import { MaintainerScore } from '@/app/types';
+import RepoLandingClient from './RepoLandingClient';
+
+export const revalidate = 3600;
+
+interface PageProps {
+  params: Promise<{ owner: string; name: string }>;
+}
+
+interface PickedIssueRow {
+  issue_url: string;
+  issue_number: number;
+  title: string;
+  labels: unknown;
+  pick_count: number;
+  repository_owner: string;
+  repository_name: string;
+}
+
+interface IssueTipRow {
+  id: string;
+  issue_url: string;
+  content: string;
+  like_count: number;
+  created_at: string;
+}
+
+export interface RepoIssue {
+  issueUrl: string;
+  issueNumber: number;
+  title: string;
+  labels: { id: string; name: string; color: string }[];
+  pickCount: number;
+}
+
+export interface RepoTip {
+  id: string;
+  issueUrl: string;
+  content: string;
+  likeCount: number;
+  createdAt: string;
+}
+
+export interface MaintainerScoreData extends MaintainerScore {
+  owner: string;
+  repo: string;
+}
+
+async function fetchMaintainerScore(
+  owner: string,
+  repo: string,
+): Promise<MaintainerScoreData | null> {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://pickssue.dev';
+  try {
+    const res = await fetch(`${baseUrl}/api/v1/score/${owner}/${repo}`, {
+      next: { revalidate: 21600 },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as {
+      owner: string;
+      repo: string;
+      grade: 'A' | 'B' | 'C';
+      avgResponseTimeHours: number;
+      avgMergeTimeHours: number;
+      mergeRate: number;
+    };
+    return {
+      owner: data.owner,
+      repo: data.repo,
+      grade: data.grade,
+      avgResponseTimeHours: data.avgResponseTimeHours,
+      avgMergeTimeHours: data.avgMergeTimeHours,
+      mergeRate: data.mergeRate,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function fetchRepoData(owner: string, repoName: string) {
+  const supabase = await createClient();
+
+  // Fetch top issues by pick count
+  const { data: issuesData } = await supabase
+    .from('picked_issues_counts')
+    .select('issue_url, repository_owner, repository_name, title, pick_count')
+    .eq('repository_owner', owner)
+    .eq('repository_name', repoName)
+    .order('pick_count', { ascending: false })
+    .limit(20);
+
+  // Fetch visible tips for this repo's issues
+  // We get all issue_urls for this repo first, then fetch tips
+  const issueUrls = (issuesData as PickedIssueRow[] | null)?.map(r => r.issue_url) ?? [];
+
+  let tipsData: IssueTipRow[] = [];
+  if (issueUrls.length > 0) {
+    const { data } = await supabase
+      .from('issue_tips')
+      .select('id, issue_url, content, like_count, created_at')
+      .in('issue_url', issueUrls)
+      .is('hidden_at', null)
+      .order('like_count', { ascending: false })
+      .limit(50);
+    tipsData = (data as IssueTipRow[] | null) ?? [];
+  }
+
+  // Also fetch tips for issues not in picked list (by repo URL pattern)
+  if (issueUrls.length === 0) {
+    const repoUrlPattern = `https://github.com/${owner}/${repoName}/issues/`;
+    const { data } = await supabase
+      .from('issue_tips')
+      .select('id, issue_url, content, like_count, created_at')
+      .like('issue_url', `${repoUrlPattern}%`)
+      .is('hidden_at', null)
+      .order('like_count', { ascending: false })
+      .limit(50);
+    tipsData = (data as IssueTipRow[] | null) ?? [];
+  }
+
+  const issues: RepoIssue[] = ((issuesData as PickedIssueRow[] | null) ?? []).map(r => ({
+    issueUrl: r.issue_url,
+    issueNumber: Number(r.issue_url.split('/').pop() ?? r.issue_number ?? 0),
+    title: r.title,
+    labels: [],
+    pickCount: Number(r.pick_count),
+  }));
+
+  const tips: RepoTip[] = tipsData.map(r => ({
+    id: r.id,
+    issueUrl: r.issue_url,
+    content: r.content,
+    likeCount: r.like_count,
+    createdAt: r.created_at,
+  }));
+
+  return { issues, tips };
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { owner, name } = await params;
+  const t = await getTranslations('repoLanding');
+
+  const title = t('metaTitle', { owner, name });
+  const description = t('metaDescription', { owner, name });
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: `/repos/${owner}/${name}`,
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+    },
+    alternates: {
+      canonical: `/repos/${owner}/${name}`,
+    },
+  };
+}
+
+export default async function RepoLandingPage({ params }: PageProps) {
+  const { owner, name } = await params;
+
+  const [{ issues, tips }, maintainerScore] = await Promise.all([
+    fetchRepoData(owner, name),
+    fetchMaintainerScore(owner, name),
+  ]);
+
+  // If no data at all, show 404
+  if (issues.length === 0 && tips.length === 0 && !maintainerScore) {
+    notFound();
+  }
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareSourceCode',
+    name: `${owner}/${name}`,
+    codeRepository: `https://github.com/${owner}/${name}`,
+    url: `https://pickssue.dev/repos/${owner}/${name}`,
+    description: `Beginner-friendly issues, contributor tips, and maintainer responsiveness score for ${owner}/${name}.`,
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <RepoLandingClient
+        owner={owner}
+        name={name}
+        issues={issues}
+        tips={tips}
+        maintainerScore={maintainerScore}
+      />
+    </>
+  );
+}

--- a/app/(main)/repos/[owner]/[name]/page.tsx
+++ b/app/(main)/repos/[owner]/[name]/page.tsx
@@ -84,34 +84,16 @@ async function fetchRepoData(owner: string, repoName: string) {
     .order('pick_count', { ascending: false })
     .limit(20);
 
-  // Fetch visible tips for this repo's issues
-  // We get all issue_urls for this repo first, then fetch tips
-  const issueUrls = (issuesData as PickedIssueRow[] | null)?.map(r => r.issue_url) ?? [];
-
-  let tipsData: IssueTipRow[] = [];
-  if (issueUrls.length > 0) {
-    const { data } = await supabase
-      .from('issue_tips')
-      .select('id, issue_url, content, like_count, created_at')
-      .in('issue_url', issueUrls)
-      .is('hidden_at', null)
-      .order('like_count', { ascending: false })
-      .limit(50);
-    tipsData = (data as IssueTipRow[] | null) ?? [];
-  }
-
-  // Also fetch tips for issues not in picked list (by repo URL pattern)
-  if (issueUrls.length === 0) {
-    const repoUrlPattern = `https://github.com/${owner}/${repoName}/issues/`;
-    const { data } = await supabase
-      .from('issue_tips')
-      .select('id, issue_url, content, like_count, created_at')
-      .like('issue_url', `${repoUrlPattern}%`)
-      .is('hidden_at', null)
-      .order('like_count', { ascending: false })
-      .limit(50);
-    tipsData = (data as IssueTipRow[] | null) ?? [];
-  }
+  // Fetch all visible tips for this repo (by repo URL pattern) regardless of pick state
+  const repoUrlPattern = `https://github.com/${owner}/${repoName}/issues/`;
+  const { data: tipsRaw } = await supabase
+    .from('issue_tips')
+    .select('id, issue_url, content, like_count, created_at')
+    .like('issue_url', `${repoUrlPattern}%`)
+    .is('hidden_at', null)
+    .order('like_count', { ascending: false })
+    .limit(50);
+  const tipsData: IssueTipRow[] = (tipsRaw as IssueTipRow[] | null) ?? [];
 
   const issues: RepoIssue[] = ((issuesData as PickedIssueRow[] | null) ?? []).map(r => ({
     issueUrl: r.issue_url,
@@ -169,8 +151,10 @@ export default async function RepoLandingPage({ params }: PageProps) {
     fetchMaintainerScore(owner, name),
   ]);
 
-  // If no data at all, show 404
-  if (issues.length === 0 && tips.length === 0 && !maintainerScore) {
+  // If there's no Pickssue-unique data for this repo, show 404.
+  // maintainerScore is always truthy due to FALLBACK_SCORE in calculateMaintainerScore,
+  // so only issues/tips determine whether the repo is worth a landing page.
+  if (issues.length === 0 && tips.length === 0) {
     notFound();
   }
 

--- a/app/(main)/repos/[owner]/[name]/page.tsx
+++ b/app/(main)/repos/[owner]/[name]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { createClient } from '@/app/lib/supabase/server';
+import { calculateMaintainerScore } from '@/app/api/recommended/maintainerScore';
 import { MaintainerScore } from '@/app/types';
 import RepoLandingClient from './RepoLandingClient';
 
@@ -54,27 +55,15 @@ async function fetchMaintainerScore(
   owner: string,
   repo: string,
 ): Promise<MaintainerScoreData | null> {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? 'https://pickssue.dev';
   try {
-    const res = await fetch(`${baseUrl}/api/v1/score/${owner}/${repo}`, {
-      next: { revalidate: 21600 },
-    });
-    if (!res.ok) return null;
-    const data = (await res.json()) as {
-      owner: string;
-      repo: string;
-      grade: 'A' | 'B' | 'C';
-      avgResponseTimeHours: number;
-      avgMergeTimeHours: number;
-      mergeRate: number;
-    };
+    const score = await calculateMaintainerScore(owner, repo);
     return {
-      owner: data.owner,
-      repo: data.repo,
-      grade: data.grade,
-      avgResponseTimeHours: data.avgResponseTimeHours,
-      avgMergeTimeHours: data.avgMergeTimeHours,
-      mergeRate: data.mergeRate,
+      owner,
+      repo,
+      grade: score.grade,
+      avgResponseTimeHours: score.avgResponseTimeHours,
+      avgMergeTimeHours: score.avgMergeTimeHours,
+      mergeRate: score.mergeRate,
     };
   } catch {
     return null;
@@ -87,7 +76,9 @@ async function fetchRepoData(owner: string, repoName: string) {
   // Fetch top issues by pick count
   const { data: issuesData } = await supabase
     .from('picked_issues_counts')
-    .select('issue_url, repository_owner, repository_name, title, pick_count')
+    .select(
+      'issue_url, issue_number, repository_owner, repository_name, title, pick_count',
+    )
     .eq('repository_owner', owner)
     .eq('repository_name', repoName)
     .order('pick_count', { ascending: false })
@@ -124,7 +115,7 @@ async function fetchRepoData(owner: string, repoName: string) {
 
   const issues: RepoIssue[] = ((issuesData as PickedIssueRow[] | null) ?? []).map(r => ({
     issueUrl: r.issue_url,
-    issueNumber: Number(r.issue_url.split('/').pop() ?? r.issue_number ?? 0),
+    issueNumber: Number(r.issue_number ?? r.issue_url.split('/').pop() ?? 0),
     title: r.title,
     labels: [],
     pickCount: Number(r.pick_count),
@@ -194,7 +185,9 @@ export default async function RepoLandingPage({ params }: PageProps) {
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c'),
+        }}
       />
       <RepoLandingClient
         owner={owner}

--- a/app/components/IssueItem.tsx
+++ b/app/components/IssueItem.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
+import Link from 'next/link';
 import { Issue, Label } from '../types';
 import { FaGithub, FaClock, FaStar, FaCodeBranch } from 'react-icons/fa';
 import {
@@ -339,9 +340,12 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
           </div>
 
           <div className="flex flex-col items-end ml-3 shrink-0 text-xs text-muted-foreground gap-1">
-            <span className="font-mono text-foreground/70">
+            <Link
+              href={`/repos/${issue.repository.owner}/${issue.repository.name}`}
+              className="font-mono text-foreground/70 hover:text-primary transition-colors"
+            >
               {issue.repository.owner}/{issue.repository.name}
-            </span>
+            </Link>
             <div className="flex items-center gap-2">
               {issue.repository.stargazersCount !== undefined && (
                 <span className="inline-flex items-center gap-0.5">
@@ -423,7 +427,13 @@ const IssueItem: React.FC<IssueItemProps> = ({ issue, compact = false }) => {
           <div className="flex items-center mt-3 text-sm text-muted-foreground flex-wrap gap-y-1">
             <div className="flex items-center mr-4">
               <span className="text-xs font-mono">
-                {issue.repository.owner}/{issue.repository.name} #{issue.number}
+                <Link
+                  href={`/repos/${issue.repository.owner}/${issue.repository.name}`}
+                  className="hover:text-primary transition-colors"
+                >
+                  {issue.repository.owner}/{issue.repository.name}
+                </Link>{' '}
+                #{issue.number}
               </span>
             </div>
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -18,11 +18,10 @@ async function getTopPickedRepos(
       .from('picked_issues_counts')
       .select('repository_owner, repository_name, pick_count')
       .order('pick_count', { ascending: false })
-      .limit(limit);
+      .limit(limit * 5);
 
     if (!data) return [];
 
-    // Deduplicate repos
     const seen = new Set<string>();
     const repos: { owner: string; name: string }[] = [];
     for (const row of data as PickedIssueCountRow[]) {
@@ -30,6 +29,7 @@ async function getTopPickedRepos(
       if (!seen.has(key)) {
         seen.add(key);
         repos.push({ owner: row.repository_owner, name: row.repository_name });
+        if (repos.length >= limit) break;
       }
     }
     return repos;

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,7 +1,52 @@
 import { MetadataRoute } from 'next';
+import { createClient } from '@/app/lib/supabase/server';
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = 'https://pickssue.dev';
+const BASE_URL = 'https://pickssue.dev';
+
+interface PickedIssueCountRow {
+  repository_owner: string;
+  repository_name: string;
+  pick_count: number;
+}
+
+async function getTopPickedRepos(
+  limit = 100,
+): Promise<{ owner: string; name: string }[]> {
+  try {
+    const supabase = await createClient();
+    const { data } = await supabase
+      .from('picked_issues_counts')
+      .select('repository_owner, repository_name, pick_count')
+      .order('pick_count', { ascending: false })
+      .limit(limit);
+
+    if (!data) return [];
+
+    // Deduplicate repos
+    const seen = new Set<string>();
+    const repos: { owner: string; name: string }[] = [];
+    for (const row of data as PickedIssueCountRow[]) {
+      const key = `${row.repository_owner}/${row.repository_name}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        repos.push({ owner: row.repository_owner, name: row.repository_name });
+      }
+    }
+    return repos;
+  } catch {
+    return [];
+  }
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const baseUrl = BASE_URL;
+  const topRepos = await getTopPickedRepos(100);
+
+  const repoEntries: MetadataRoute.Sitemap = topRepos.map(({ owner, name }) => ({
+    url: `${baseUrl}/repos/${owner}/${name}`,
+    changeFrequency: 'daily',
+    priority: 0.8,
+  }));
 
   return [
     {
@@ -35,5 +80,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'monthly',
       priority: 0.3,
     },
+    ...repoEntries,
   ];
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -389,6 +389,19 @@
     "useGistDesc": "Use the repository list from your cloud backup",
     "combineDesc": "Combine both repository lists"
   },
+  "repoLanding": {
+    "heading": "Contribute to {owner}/{name} on Pickssue",
+    "metaTitle": "Contribute to {owner}/{name} - Beginner-Friendly Issues",
+    "metaDescription": "Discover beginner-friendly issues, contributor tips, and maintainer responsiveness for {owner}/{name} on Pickssue.",
+    "issuesHeading": "Beginner-Friendly Issues",
+    "noIssues": "No picked issues found for this repository yet.",
+    "tipsHeading": "Contributor Tips",
+    "noTips": "No contributor tips yet for this repository.",
+    "tipsSortPopular": "Popular",
+    "tipsSortRecent": "Recent",
+    "ctaDesc": "Find more beginner-friendly issues across all repositories.",
+    "ctaLink": "Browse all issues on Pickssue"
+  },
   "tips": {
     "toggle": "Tips",
     "add": "Add a tip",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -389,6 +389,19 @@
     "useGistDesc": "클라우드 저장소 목록을 사용합니다",
     "combineDesc": "두 저장소 목록을 합칩니다"
   },
+  "repoLanding": {
+    "heading": "Pickssue에서 {owner}/{name} 기여하기",
+    "metaTitle": "{owner}/{name} 기여하기 - 입문자 이슈 모음",
+    "metaDescription": "Pickssue에서 {owner}/{name}의 입문자 친화적 이슈, 기여 팁, 메인테이너 응답성을 확인하세요.",
+    "issuesHeading": "입문자 친화 이슈",
+    "noIssues": "이 저장소에 아직 픽된 이슈가 없습니다.",
+    "tipsHeading": "기여 팁",
+    "noTips": "이 저장소에 아직 기여 팁이 없습니다.",
+    "tipsSortPopular": "인기순",
+    "tipsSortRecent": "최신순",
+    "ctaDesc": "모든 저장소의 입문자 친화 이슈를 찾아보세요.",
+    "ctaLink": "Pickssue에서 이슈 둘러보기"
+  },
   "tips": {
     "toggle": "기여 팁",
     "add": "팁 작성",


### PR DESCRIPTION
## Summary

- `app/(main)/repos/[owner]/[name]/page.tsx` SSR+ISR 페이지 신설 (revalidate 3600)
- Supabase `picked_issues_counts` 뷰와 `issue_tips` 테이블에서 레포별 데이터 집계
- `RepoLandingClient.tsx` 클라이언트 컴포넌트: 인기순/최신순 팁 탭, 이슈 목록, maintainer 스코어 뱃지
- `app/components/IssueItem.tsx`에 `/repos/[owner]/[name]` 내부 링크 추가 (compact/full 뷰 모두)
- `app/sitemap.ts` 를 async로 전환, Pick된 상위 레포 최대 100개 자동 포함

## Test plan

- [ ] `/repos/facebook/react` 등 Pick이 있는 레포 URL 접근 시 이슈 목록, 팁, maintainer 뱃지 렌더링 확인
- [ ] 데이터 없는 레포(`/repos/unknown/none`) 접근 시 404 반환 확인
- [ ] `IssueItem` 컴포넌트에서 레포 이름 클릭 시 `/repos/[owner]/[name]`으로 이동 확인
- [ ] `/sitemap.xml` 에 레포 페이지 URL 포함 확인
- [ ] JSON-LD `SoftwareSourceCode` 구조화 데이터 head에 포함 확인
- [ ] 팁 정렬 버튼(인기순/최신순) 동작 확인

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)